### PR TITLE
Escape textarea field output

### DIFF
--- a/src/includes/class-theme-my-login-form-field.php
+++ b/src/includes/class-theme-my-login-form-field.php
@@ -685,7 +685,7 @@ class Theme_My_Login_Form_Field {
 			case 'textarea' :
 				$output .= $label;
 				$output .= $args['control_before'];
-				$output .= '<textarea name="' . $this->get_name() . '"' . $attributes . '>' . $this->get_value() . "</textarea>\n";
+				$output .= '<textarea name="' . $this->get_name() . '"' . $attributes . '>' . esc_textarea( $this->get_value() ) . "</textarea>\n";
 				$output .= $args['control_after'];
 				break;
 

--- a/tests/test-form-field.php
+++ b/tests/test-form-field.php
@@ -34,6 +34,16 @@ class Test_Form_Field extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'value="jane&quot;doe"', $output );
 	}
 
+	public function test_textarea_field_escapes_its_value() {
+		$output = $this->field( 'bio', array(
+			'type'  => 'textarea',
+			'value' => '</textarea><script>alert(1)</script>',
+		) )->render();
+
+		$this->assertStringContainsString( '&lt;/textarea&gt;&lt;script&gt;alert(1)&lt;/script&gt;', $output );
+		$this->assertStringNotContainsString( '<script>', $output );
+	}
+
 	public function test_label_is_linked_to_the_field_id() {
 		$output = $this->field( 'user_login', array(
 			'label' => 'Username',


### PR DESCRIPTION
## Summary
- `Theme_My_Login_Form_Field::render()` printed the `textarea` field's value raw between the tags, unlike every other field type (`esc_attr` for inputs, `esc_html` for dropdown options).
- No built-in TML form uses the `textarea` type today, but it's a stored-XSS trap for any custom/extension form that does.

## Changes
- Escape the value with `esc_textarea()` before output.
- Add `test_textarea_field_escapes_its_value` to `tests/test-form-field.php`.

## Test plan
- [x] `vendor/bin/phpunit --filter Test_Form_Field` passes (10/10)