### PR TITLE
Drop redundant push trigger from test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Test
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
## Summary
- `master` is now protected by a ruleset requiring PRs and a passing `phpunit` check, and blocking direct/force pushes.
- That made the workflow's `push: branches: [master]` trigger redundant: the only pushes to master are merge commits whose contents already passed the `pull_request` run.

## Changes
- Remove the `push` trigger from `.github/workflows/test.yml`, leaving `pull_request` as the sole trigger.

## Test plan
- [x] Ruleset confirmed active via `gh api repos/theme-my-login/theme-my-login/rulesets/20669780` (required status check: `phpunit`, PR required, non-fast-forward + deletion blocked, no bypass)