### PR TITLE
chore: add WordPress Coding Standards linting and fix full backlog

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,24 @@ on:
     branches: [ master ]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run phpcs
+        run: composer run lint
+
   phpunit:
     runs-on: ubuntu-latest
 

--- a/composer.json
+++ b/composer.json
@@ -9,15 +9,21 @@
         "phpunit/phpunit": "^9.6",
         "yoast/phpunit-polyfills": "^2.0",
         "wp-phpunit/wp-phpunit": "^7.0",
-        "roots/wordpress-no-content": "^7.0"
+        "roots/wordpress-no-content": "^7.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+        "wp-coding-standards/wpcs": "^3.1",
+        "phpcompatibility/phpcompatibility-wp": "^2.1"
     },
     "config": {
         "allow-plugins": {
-            "composer/installers": true
+            "composer/installers": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
     "scripts": {
         "test": "phpunit",
-        "test:strict": "WP_TESTS_STRICT_DEPRECATIONS=1 php -d error_reporting=-1 vendor/bin/phpunit --fail-on-risky"
+        "test:strict": "WP_TESTS_STRICT_DEPRECATIONS=1 php -d error_reporting=-1 vendor/bin/phpunit --fail-on-risky",
+        "lint": "phpcs",
+        "lint:fix": "phpcbf"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,105 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0ef1a09eba66c314afe6fd92f3814c1a",
+    "content-hash": "6d020f77846c5db2dd6e09a1be857c5b",
     "packages": [],
     "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.2",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.2",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-05-06T08:26:05+00:00"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "2.1.0",
@@ -310,6 +406,394 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
+            "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "244d7b04fc4bc2117c15f5abe23eb933b5f02bbf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/244d7b04fc4bc2117c15f5abe23eb933b5f02bbf",
+                "reference": "244d7b04fc4bc2117c15f5abe23eb933b5f02bbf",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/security/policy",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcompatibility",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-09-19T17:43:28+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "7c8d18b4d90dac9e86b0869a608fa09158e168fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/7c8d18b4d90dac9e86b0869a608fa09158e168fa",
+                "reference": "7c8d18b4d90dac9e86b0869a608fa09158e168fa",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0",
+                "squizlabs/php_codesniffer": "^3.3"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityWP/security/policy",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcompatibility",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-10-18T00:05:59+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/39467533fdb742446d68c1d10ac33d625ee0311c",
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.2.3",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-07-27T11:13:17+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "phpcs4",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-07-27T10:28:41+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1808,6 +2292,85 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.13.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-08-06T00:17:32+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.3.1",
             "source": {
@@ -1856,6 +2419,72 @@
                 }
             ],
             "time": "2025-11-17T20:03:58+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "3.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/ec2ff942335f33683a5957a85d138753876a05cf",
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
+                "php": ">=7.2",
+                "phpcsstandards/phpcsextra": "^1.5.1",
+                "phpcsstandards/phpcsutils": "^1.2.3",
+                "squizlabs/php_codesniffer": "^3.13.5"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^10.0.0@dev",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^8.0 || ^9.0"
+            },
+            "suggest": {
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "custom"
+                }
+            ],
+            "time": "2026-07-27T11:53:23+00:00"
         },
         {
             "name": "wp-phpunit/wp-phpunit",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<ruleset name="Theme My Login">
+	<description>WordPress Coding Standards for Theme My Login</description>
+
+	<file>src</file>
+	<file>theme-my-login.php</file>
+
+	<exclude-pattern>src/assets/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/build/*</exclude-pattern>
+
+	<arg value="sp"/>
+	<arg name="basepath" value="."/>
+	<arg name="colors"/>
+	<arg name="extensions" value="php"/>
+	<arg name="parallel" value="8"/>
+
+	<!-- composer.json pins php >=7.4 as the minimum supported version. -->
+	<config name="testVersion" value="7.4-"/>
+	<config name="minimum_supported_wp_version" value="5.0"/>
+
+	<rule ref="WordPress-Extra">
+		<!-- Multi-file plugin with one class per admin/includes concern; not all class files follow the class-{name}.php convention. -->
+		<exclude name="WordPress.Files.FileName"/>
+	</rule>
+
+	<rule ref="PHPCompatibilityWP"/>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="theme-my-login"/>
+			</property>
+		</properties>
+	</rule>
+</ruleset>

--- a/src/admin/class-theme-my-login-admin.php
+++ b/src/admin/class-theme-my-login-admin.php
@@ -61,14 +61,17 @@ final class Theme_My_Login_Admin {
 	 *                not have the capability required.
 	 */
 	public function add_menu_item( $args = array() ) {
-		$args = wp_parse_args( $args, array(
-			'page_title'  => '',
-			'menu_title'  => '',
-			'menu_slug'   => '',
-			'parent_slug' => 'theme-my-login',
-			'capability'  => 'manage_options',
-			'function'    => 'tml_admin_settings_page',
-		) );
+		$args = wp_parse_args(
+			$args,
+			array(
+				'page_title'  => '',
+				'menu_title'  => '',
+				'menu_slug'   => '',
+				'parent_slug' => 'theme-my-login',
+				'capability'  => 'manage_options',
+				'function'    => 'tml_admin_settings_page',
+			)
+		);
 
 		if ( empty( $args['page_title'] ) || empty( $args['menu_title'] ) || empty( $args['menu_slug'] ) ) {
 			return;

--- a/src/admin/extensions.php
+++ b/src/admin/extensions.php
@@ -18,9 +18,12 @@
  * @return array|WP_Error The extensions array or WP_Error on failure.
  */
 function tml_admin_get_extensions_feed( $args = array() ) {
-	$args = wp_parse_args( $args, array(
-		'number' => 12,
-	) );
+	$args = wp_parse_args(
+		$args,
+		array(
+			'number' => 12,
+		)
+	);
 
 	$transient_key = 'tml_extensions_feed-' . md5( http_build_query( $args ) );
 
@@ -28,9 +31,12 @@ function tml_admin_get_extensions_feed( $args = array() ) {
 	if ( false === $feed ) {
 		$url = add_query_arg( $args, THEME_MY_LOGIN_EXTENSIONS_API_URL );
 
-		$response = wp_remote_get( $url, array(
-			'timeout' => 30,
-		) );
+		$response = wp_remote_get(
+			$url,
+			array(
+				'timeout' => 30,
+			)
+		);
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
@@ -38,7 +44,7 @@ function tml_admin_get_extensions_feed( $args = array() ) {
 		$code    = wp_remote_retrieve_response_code( $response );
 		$message = wp_remote_retrieve_response_message( $response );
 
-		if ( '200' != $code ) {
+		if ( 200 !== (int) $code ) {
 			return new WP_Error( 'http_error_' . $code, $message );
 		}
 
@@ -60,16 +66,21 @@ function tml_admin_extensions_page() {
 	global $title, $plugin_page;
 
 	$extensions = tml_admin_get_extensions_feed();
-?>
+	?>
 
 <div class="wrap">
-	<h1><?php echo esc_html( $title ) ?></h1>
+	<h1><?php echo esc_html( $title ); ?></h1>
 	<hr class="wp-header-end">
 
 	<?php if ( is_wp_error( $extensions ) ) : ?>
 
 		<h3><?php echo esc_html_e( 'Whoops! Looks like there was an error fetching extensions from the server. Please try again.', 'theme-my-login' ); ?></h3>
-		<p><?php echo esc_html( sprintf( __( 'Error: %s', 'theme-my-login' ), $extensions->get_error_message() ) ); ?></p>
+		<p>
+		<?php
+		/* translators: %s: The error message. */
+		echo esc_html( sprintf( __( 'Error: %s', 'theme-my-login' ), $extensions->get_error_message() ) );
+		?>
+		</p>
 
 	<?php else : ?>
 
@@ -101,11 +112,11 @@ function tml_admin_extensions_page() {
 	<?php endif; ?>
 
 	<div class="tml-view-all-extensions-wrap">
-		<a class="tml-view-all-extensions-link" href="<?php echo THEME_MY_LOGIN_EXTENSIONS_URL; ?>"><?php esc_html_e( 'View All Extensions', 'theme-my-login' ); ?></a>
+		<a class="tml-view-all-extensions-link" href="<?php echo esc_url( THEME_MY_LOGIN_EXTENSIONS_URL ); ?>"><?php esc_html_e( 'View All Extensions', 'theme-my-login' ); ?></a>
 	</div>
 </div>
 
-<?php
+	<?php
 }
 
 /**
@@ -119,13 +130,14 @@ function tml_admin_handle_extension_licenses() {
 		return;
 	}
 
-	if ( tml_get_request_value('option_page') !== 'theme-my-login-licenses' ) {
+	if ( tml_get_request_value( 'option_page' ) !== 'theme-my-login-licenses' ) {
 		return;
 	}
 
 	check_admin_referer( 'theme-my-login-licenses-options' );
 
 	if ( ! current_user_can( 'manage_options' ) ) {
+		// phpcs:ignore WordPress.WP.I18n.MissingArgDomain, WordPress.Security.EscapeOutput.OutputNotEscaped -- reusing WP core's translated string verbatim (see wp-admin/options-general.php), not a TML-specific string.
 		wp_die( __( 'Sorry, you are not allowed to manage options for this site.' ) );
 	}
 
@@ -134,10 +146,12 @@ function tml_admin_handle_extension_licenses() {
 
 		// Handle license activations
 		if ( isset( $_POST['tml_activate_license'][ $extension->get_name() ] ) ) {
-			if ( $response = tml_activate_extension_license( $extension ) ) {
+			$response = tml_activate_extension_license( $extension );
+			if ( $response ) {
 				if ( is_wp_error( $response ) ) {
 					$extension->set_license_status();
-					add_settings_error( 'tml_activate_license',
+					add_settings_error(
+						'tml_activate_license',
 						$response->get_error_code(),
 						$response->get_error_message()
 					);
@@ -149,9 +163,11 @@ function tml_admin_handle_extension_licenses() {
 
 		// Handle license deactivations
 		if ( isset( $_POST['tml_deactivate_license'][ $extension->get_name() ] ) ) {
-			if ( $response = tml_deactivate_extension_license( $extension ) ) {
+			$response = tml_deactivate_extension_license( $extension );
+			if ( $response ) {
 				if ( is_wp_error( $response ) ) {
-					add_settings_error( 'tml_deactivate_license',
+					add_settings_error(
+						'tml_deactivate_license',
 						$response->get_error_code(),
 						$response->get_error_message()
 					);
@@ -170,14 +186,17 @@ function tml_admin_handle_extension_licenses() {
  */
 function tml_admin_ajax_activate_extension_license() {
 	if ( ! check_ajax_referer( 'theme-my-login-licenses-options', '_wpnonce', false ) ) {
+		// phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated string verbatim (see wp-includes/class-wp-customize-manager.php), not a TML-specific string.
 		tml_send_ajax_error( __( 'There was an authentication problem. Please reload and try again.' ) );
 	}
 
-	if ( ! $extension = tml_get_extension( tml_get_request_value( 'extension', 'post' ) ) ) {
+	$extension = tml_get_extension( tml_get_request_value( 'extension', 'post' ) );
+	if ( ! $extension ) {
 		tml_send_ajax_error( __( 'Invalid extension.', 'theme-my-login' ) );
 	}
 
 	if ( ! current_user_can( 'manage_options' ) ) {
+		// phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated string verbatim (see wp-admin/options-general.php), not a TML-specific string.
 		tml_send_ajax_error( __( 'Sorry, you are not allowed to manage options for this site.' ) );
 	}
 
@@ -204,14 +223,17 @@ function tml_admin_ajax_activate_extension_license() {
  */
 function tml_admin_ajax_deactivate_extension_license() {
 	if ( ! check_ajax_referer( 'theme-my-login-licenses-options', '_wpnonce', false ) ) {
+		// phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated string verbatim (see wp-includes/class-wp-customize-manager.php), not a TML-specific string.
 		tml_send_ajax_error( __( 'There was an authentication problem. Please reload and try again.' ) );
 	}
 
-	if ( ! $extension = tml_get_extension( tml_get_request_value( 'extension', 'post' ) ) ) {
+	$extension = tml_get_extension( tml_get_request_value( 'extension', 'post' ) );
+	if ( ! $extension ) {
 		tml_send_ajax_error( __( 'Invalid extension.', 'theme-my-login' ) );
 	}
 
 	if ( ! current_user_can( 'manage_options' ) ) {
+		// phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated string verbatim (see wp-admin/options-general.php), not a TML-specific string.
 		tml_send_ajax_error( __( 'Sorry, you are not allowed to manage options for this site.' ) );
 	}
 
@@ -238,7 +260,7 @@ function tml_admin_check_extension_licenses() {
 		return;
 	}
 
-	if ( 'theme-my-login-licenses' != $plugin_page ) {
+	if ( 'theme-my-login-licenses' !== $plugin_page ) {
 		return;
 	}
 
@@ -246,7 +268,7 @@ function tml_admin_check_extension_licenses() {
 		if ( ! $extension->get_license_key() ) {
 			continue;
 		}
-		if ( 'valid' != $extension->get_license_status() ) {
+		if ( 'valid' !== $extension->get_license_status() ) {
 			continue;
 		}
 		$status = tml_check_extension_license( $extension );
@@ -276,7 +298,7 @@ function tml_admin_extension_update_message( $data, $response ) {
 	if ( empty( $response->package ) ) {
 		echo ' ' . sprintf(
 			'<em>In order to enable automatic updates, please enter and activate your <a href="%1$s">license key</a>.',
-			admin_url( 'admin.php?page=theme-my-login-licenses' )
+			esc_url( admin_url( 'admin.php?page=theme-my-login-licenses' ) )
 		);
 	}
 }

--- a/src/admin/functions.php
+++ b/src/admin/functions.php
@@ -30,7 +30,7 @@ function tml_admin_is_plugin_page( $page = '' ) {
 	global $plugin_page;
 
 	if ( ! empty( $page ) ) {
-		return ( "theme-my-login-$page" == $plugin_page ) || ( "tml-$page" == $plugin_page );
+		return ( "theme-my-login-$page" === $plugin_page ) || ( "tml-$page" === $plugin_page );
 	}
 
 	return ( strpos( $plugin_page, 'theme-my-login' ) === 0 ) || ( strpos( $plugin_page, 'tml-' ) === 0 );
@@ -62,23 +62,29 @@ function tml_admin_add_menu_items() {
 	}
 
 	// Add the main menu item
-	tml_admin_add_menu_item( array(
-		'page_title'  => esc_html__( 'Theme My Login Settings', 'theme-my-login' ),
-		'menu_title'  => esc_html__( 'Theme My Login',          'theme-my-login' ),
-		'menu_slug'   => 'theme-my-login',
-		'menu_icon'   => 'data:image/svg+xml;base64,' . base64_encode(
-			file_get_contents( THEME_MY_LOGIN_PATH . 'admin/assets/images/logo.svg' )
-		),
-		'parent_slug' => false,
-	) );
+	tml_admin_add_menu_item(
+		array(
+			'page_title'  => esc_html__( 'Theme My Login Settings', 'theme-my-login' ),
+			'menu_title'  => esc_html__( 'Theme My Login', 'theme-my-login' ),
+			'menu_slug'   => 'theme-my-login',
+			// phpcs:disable WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- reading a local plugin asset and base64-encoding it into a data: URI for the admin menu icon, not a remote fetch or obfuscation.
+			'menu_icon'   => 'data:image/svg+xml;base64,' . base64_encode(
+				file_get_contents( THEME_MY_LOGIN_PATH . 'admin/assets/images/logo.svg' )
+			),
+			// phpcs:enable WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+			'parent_slug' => false,
+		)
+	);
 
 	// Add the submenu item
-	tml_admin_add_menu_item( array(
-		'page_title'  => esc_html__( 'Theme My Login Settings', 'theme-my-login' ),
-		'menu_title'  => esc_html__( 'General',                 'theme-my-login' ),
-		'menu_slug'   => 'theme-my-login',
-		'parent_slug' => 'theme-my-login',
-	) );
+	tml_admin_add_menu_item(
+		array(
+			'page_title'  => esc_html__( 'Theme My Login Settings', 'theme-my-login' ),
+			'menu_title'  => esc_html__( 'General', 'theme-my-login' ),
+			'menu_slug'   => 'theme-my-login',
+			'parent_slug' => 'theme-my-login',
+		)
+	);
 
 	$has_licenses = false;
 
@@ -95,23 +101,27 @@ function tml_admin_add_menu_items() {
 
 	if ( $has_licenses ) {
 		// Add the licenses menu item
-		tml_admin_add_menu_item( array(
-			'page_title'  => esc_html__( 'Theme My Login Licenses', 'theme-my-login' ),
-			'menu_title'  => esc_html__( 'Licenses',                'theme-my-login' ),
-			'menu_slug'   => 'theme-my-login-licenses',
-			'parent_slug' => 'theme-my-login',
-		) );
+		tml_admin_add_menu_item(
+			array(
+				'page_title'  => esc_html__( 'Theme My Login Licenses', 'theme-my-login' ),
+				'menu_title'  => esc_html__( 'Licenses', 'theme-my-login' ),
+				'menu_slug'   => 'theme-my-login-licenses',
+				'parent_slug' => 'theme-my-login',
+			)
+		);
 		add_settings_section( 'tml_settings_licenses', '', '__return_null', 'theme-my-login-licenses' );
 	}
 
 	// Add the extensions menu item
-	tml_admin_add_menu_item( array(
-		'page_title'  => esc_html__( 'Theme My Login Extensions', 'theme-my-login' ),
-		'menu_title'  => esc_html__( 'Extensions',                'theme-my-login' ),
-		'menu_slug'   => 'theme-my-login-extensions',
-		'parent_slug' => 'theme-my-login',
-		'function'    => 'tml_admin_extensions_page',
-	) );
+	tml_admin_add_menu_item(
+		array(
+			'page_title'  => esc_html__( 'Theme My Login Extensions', 'theme-my-login' ),
+			'menu_title'  => esc_html__( 'Extensions', 'theme-my-login' ),
+			'menu_slug'   => 'theme-my-login-extensions',
+			'parent_slug' => 'theme-my-login',
+			'function'    => 'tml_admin_extensions_page',
+		)
+	);
 }
 
 /**
@@ -124,14 +134,24 @@ function tml_admin_enqueue_style_and_scripts() {
 
 	wp_enqueue_style( 'theme-my-login-admin', THEME_MY_LOGIN_URL . "admin/assets/styles/theme-my-login-admin$suffix.css", array(), THEME_MY_LOGIN_VERSION );
 
-	wp_enqueue_script( 'theme-my-login-admin', THEME_MY_LOGIN_URL . "admin/assets/scripts/theme-my-login-admin$suffix.js", array( 'jquery', 'postbox' ), THEME_MY_LOGIN_VERSION );
-	wp_localize_script( 'theme-my-login-admin', 'tmlAdmin', array(
-		'ajaxUrl'         => admin_url( 'admin-ajax.php' ),
-		'interimLoginUrl' => site_url( add_query_arg( array(
-			'interim-login' => 1,
-			'wp_lang'       => get_user_locale(),
-		), 'wp-login.php' ), 'login' ),
-	) );
+	wp_enqueue_script( 'theme-my-login-admin', THEME_MY_LOGIN_URL . "admin/assets/scripts/theme-my-login-admin$suffix.js", array( 'jquery', 'postbox' ), THEME_MY_LOGIN_VERSION, true );
+	wp_localize_script(
+		'theme-my-login-admin',
+		'tmlAdmin',
+		array(
+			'ajaxUrl'         => admin_url( 'admin-ajax.php' ),
+			'interimLoginUrl' => site_url(
+				add_query_arg(
+					array(
+						'interim-login' => 1,
+						'wp_lang'       => get_user_locale(),
+					),
+					'wp-login.php'
+				),
+				'login'
+			),
+		)
+	);
 }
 
 /**
@@ -145,7 +165,7 @@ function tml_admin_notices() {
 	$screen = get_current_screen();
 
 	// Bail if not on Dashboard or a TML page
-	if ( 'dashboard' != $screen->id && 'theme-my-login' != $screen->parent_base ) {
+	if ( 'dashboard' !== $screen->id && 'theme-my-login' !== $screen->parent_base ) {
 		return;
 	}
 
@@ -154,13 +174,14 @@ function tml_admin_notices() {
 		return;
 	}
 
-	$is_pre_7 = ( $previous_version = tml_get_previous_version() ) && version_compare( $previous_version, '7.0', '<' );
+	$previous_version = tml_get_previous_version();
+	$is_pre_7         = $previous_version && version_compare( $previous_version, '7.0', '<' );
 
-	if ( 'theme-my-login-extensions' == $plugin_page && $is_pre_7 ) {
+	if ( 'theme-my-login-extensions' === $plugin_page && $is_pre_7 ) {
 		?>
 
 		<div class="notice notice-info">
-			<p><?php _e( 'As a token of our gratitude, we would like to offer your an incentive for upgrading Theme My Login to version 7.0. For a limited time, we are offering a <strong>20% discount</strong> when you use the code <strong>SAVINGFACE</strong> at checkout. Act now - this offer won\'t last!', 'theme-my-login' ); ?></p>
+			<p><?php echo wp_kses_post( __( 'As a token of our gratitude, we would like to offer your an incentive for upgrading Theme My Login to version 7.0. For a limited time, we are offering a <strong>20% discount</strong> when you use the code <strong>SAVINGFACE</strong> at checkout. Act now - this offer won\'t last!', 'theme-my-login' ) ); ?></p>
 		</div>
 
 		<?php
@@ -172,23 +193,34 @@ function tml_admin_notices() {
 
 		$notice_key = 'new_extension-' . $extension->info->slug;
 
-		if ( ! in_array( $notice_key, get_site_option( '_tml_dismissed_notices', array() ) ) ) : ?>
+		if ( ! in_array( $notice_key, get_site_option( '_tml_dismissed_notices', array() ), true ) ) :
+			?>
 
-		<div class="notice notice-info tml-notice is-dismissible" data-notice="<?php echo $notice_key; ?>" data-nonce="<?php echo wp_create_nonce( $notice_key ); ?>">
-			<?php echo implode( "\n", array(
-				'<p>' . __( 'A new <strong>Theme My Login</strong> extension is available!', 'theme-my-login' ) . '</p>',
-				'<p>' . sprintf( '<strong>%s</strong>: %s',
-					$extension->info->title,
-					$extension->info->excerpt
-				) . '</p>',
-				'<p>' . sprintf( '<a class="button button-primary" href="%s">%s</a>',
-					$extension->info->link,
-					__( 'Get This Extension', 'theme-my-login' )
-				) . '</p>',
-			) ); ?>
+		<div class="notice notice-info tml-notice is-dismissible" data-notice="<?php echo esc_attr( $notice_key ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( $notice_key ) ); ?>">
+			<?php
+			echo wp_kses_post(
+				implode(
+					"\n",
+					array(
+						'<p>' . __( 'A new <strong>Theme My Login</strong> extension is available!', 'theme-my-login' ) . '</p>',
+						'<p>' . sprintf(
+							'<strong>%s</strong>: %s',
+							esc_html( $extension->info->title ),
+							esc_html( $extension->info->excerpt )
+						) . '</p>',
+						'<p>' . sprintf(
+							'<a class="button button-primary" href="%s">%s</a>',
+							esc_url( $extension->info->link ),
+							__( 'Get This Extension', 'theme-my-login' )
+						) . '</p>',
+					)
+				)
+			);
+			?>
 		</div>
 
-		<?php endif;
+			<?php
+		endif;
 	}
 }
 
@@ -204,7 +236,7 @@ function tml_admin_ajax_dismiss_notice() {
 	if ( ! current_user_can( 'activate_plugins' ) ) {
 		wp_send_json_error( null, 403 );
 	}
-	$dismissed_notices = get_site_option( '_tml_dismissed_notices', array() );
+	$dismissed_notices   = get_site_option( '_tml_dismissed_notices', array() );
 	$dismissed_notices[] = sanitize_key( $_POST['notice'] );
 	update_site_option( '_tml_dismissed_notices', $dismissed_notices );
 	wp_send_json_success();
@@ -237,11 +269,11 @@ function tml_admin_update() {
 
 	// Set the first time install date
 	if ( ! get_site_option( '_tml_installed_at' ) ) {
-		update_site_option( '_tml_installed_at', current_time( 'timestamp' ) );
+		update_site_option( '_tml_installed_at', time() );
 	}
 
 	// Set the update date
-	update_site_option( '_tml_updated_at', current_time( 'timestamp' ) );
+	update_site_option( '_tml_updated_at', time() );
 
 	// Store the previous version
 	if ( ! empty( $version ) ) {
@@ -277,7 +309,8 @@ function tml_sanitize_slug( $slug ) {
  * @since 7.0
  */
 function tml_admin_add_nav_menu_meta_box() {
-	add_meta_box( 'tml_actions',
+	add_meta_box(
+		'tml_actions',
 		__( 'Theme My Login Actions', 'theme-my-login' ),
 		'tml_admin_nav_menu_meta_box',
 		'nav-menus',
@@ -294,24 +327,34 @@ function tml_admin_add_nav_menu_meta_box() {
 function tml_admin_nav_menu_meta_box() {
 	global $_nav_menu_placeholder, $nav_menu_selected_id;
 
+	// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- mirrors WP core's own placeholder-ID counter pattern in wp-admin/includes/nav-menu.php.
 	$_nav_menu_placeholder = 0 > $_nav_menu_placeholder ? $_nav_menu_placeholder - 1 : -1;
 
-	$actions = wp_list_filter( tml_get_actions(), array(
-		'show_in_nav_menus' => true
-	) );
+	$actions = wp_list_filter(
+		tml_get_actions(),
+		array(
+			'show_in_nav_menus' => true,
+		)
+	);
 	?>
 
 	<div id="tml-action" class="posttypediv">
 		<div class="tabs-panel tabs-panel-active">
 			<ul class="categorychecklist form-no-clear">
-				<?php echo walk_nav_menu_tree( array_map( 'wp_setup_nav_menu_item', $actions ), 0, (object) array(
-					'walker' => new Walker_Nav_Menu_Checklist(),
-				) ); ?>
+				<?php
+				echo walk_nav_menu_tree(
+					array_map( 'wp_setup_nav_menu_item', $actions ),
+					0,
+					(object) array(
+						'walker' => new Walker_Nav_Menu_Checklist(),
+					)
+				);
+				?>
 			</ul>
 		</div>
 		<p class="button-controls wp-clearfix">
 			<span class="add-to-menu">
-				<input type="submit"<?php wp_nav_menu_disabled_check( $nav_menu_selected_id ); ?> class="button submit-add-to-menu right" value="<?php esc_attr_e( 'Add to Menu' ); ?>" name="add-tml-action-menu-item" id="submit-tml-action" />
+				<input type="submit"<?php wp_nav_menu_disabled_check( $nav_menu_selected_id ); ?> class="button submit-add-to-menu right" value="<?php esc_attr_e( 'Add to Menu' ); /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated "Add to Menu" string (see wp-admin/includes/nav-menu.php), not a TML-specific string. */ ?>" name="add-tml-action-menu-item" id="submit-tml-action" />
 				<span class="spinner"></span>
 			</span>
 		</p>
@@ -328,7 +371,7 @@ function tml_admin_nav_menu_meta_box() {
  * @param string $walker The name of the walker class.
  * @return string The name of the walker class.
  */
-function tml_admin_filter_edit_nav_menu_walker( $walker )  {
+function tml_admin_filter_edit_nav_menu_walker( $walker ) {
 	$walker = 'Theme_My_Login_Walker_Nav_Menu_Edit';
 	if ( ! class_exists( $walker ) ) {
 		require_once THEME_MY_LOGIN_PATH . 'admin/class-theme-my-login-walker-nav-menu-edit.php';
@@ -347,13 +390,15 @@ function tml_admin_filter_edit_nav_menu_walker( $walker )  {
  * @param string $context The plugin context.
  * @return array The plugin action links.
  */
-function tml_admin_filter_plugin_action_links( $actions, $file, $data, $context ) {
-	if ( 'theme-my-login/theme-my-login.php' == $file ) {
-		$actions['settings'] = sprintf( '<a href="%1$s">%2$s</a>',
+function tml_admin_filter_plugin_action_links( $actions, $file, $data, $context ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $data/$context are unused but required by the plugin_action_links_{$file} filter signature.
+	if ( 'theme-my-login/theme-my-login.php' === $file ) {
+		$actions['settings']   = sprintf(
+			'<a href="%1$s">%2$s</a>',
 			admin_url( 'admin.php?page=theme-my-login' ),
-			__( 'Settings' )
+			__( 'Settings' ) // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated "Settings" string, not a TML-specific string.
 		);
-		$actions['extensions'] = sprintf( '<a href="%1$s">%2$s</a>',
+		$actions['extensions'] = sprintf(
+			'<a href="%1$s">%2$s</a>',
 			admin_url( 'admin.php?page=theme-my-login-extensions' ),
 			__( 'Extensions', 'theme-my-login' )
 		);

--- a/src/admin/hooks.php
+++ b/src/admin/hooks.php
@@ -15,21 +15,21 @@
 add_action( 'admin_enqueue_scripts', 'tml_admin_enqueue_style_and_scripts' );
 
 // Notices
-add_action( 'admin_notices',              'tml_admin_notices'             );
+add_action( 'admin_notices', 'tml_admin_notices' );
 add_action( 'wp_ajax_tml-dismiss-notice', 'tml_admin_ajax_dismiss_notice' );
 
 // Extensions
-add_action( 'admin_init', 'tml_admin_handle_extension_licenses'     );
-add_action( 'admin_init', 'tml_admin_check_extension_licenses'      );
+add_action( 'admin_init', 'tml_admin_handle_extension_licenses' );
+add_action( 'admin_init', 'tml_admin_check_extension_licenses' );
 add_action( 'admin_init', 'tml_admin_add_extension_update_messages' );
 
 // Settings
 if ( is_multisite() ) {
-	add_action( 'network_admin_menu',                'tml_admin_add_menu_items'    );
-	add_action( 'admin_init',                        'tml_admin_register_settings' );
-	add_action( 'network_admin_edit_theme-my-login', 'tml_admin_save_ms_settings'  );
+	add_action( 'network_admin_menu', 'tml_admin_add_menu_items' );
+	add_action( 'admin_init', 'tml_admin_register_settings' );
+	add_action( 'network_admin_edit_theme-my-login', 'tml_admin_save_ms_settings' );
 } else {
-	add_action( 'admin_menu', 'tml_admin_add_menu_items'    );
+	add_action( 'admin_menu', 'tml_admin_add_menu_items' );
 	add_action( 'admin_init', 'tml_admin_register_settings' );
 }
 add_action( 'current_screen', 'tml_admin_add_settings_help_tabs' );
@@ -41,7 +41,7 @@ add_action( 'admin_init', 'tml_admin_update' );
 add_action( 'admin_head-nav-menus.php', 'tml_admin_add_nav_menu_meta_box', 10 );
 
 // AJAX
-add_action( 'wp_ajax_tml-activate-extension-license',   'tml_admin_ajax_activate_extension_license' );
+add_action( 'wp_ajax_tml-activate-extension-license', 'tml_admin_ajax_activate_extension_license' );
 add_action( 'wp_ajax_tml-deactivate-extension-license', 'tml_admin_ajax_deactivate_extension_license' );
 
 /**

--- a/src/admin/settings.php
+++ b/src/admin/settings.php
@@ -93,28 +93,31 @@ function tml_admin_get_settings_sections() {
 	 *
 	 * @param array $sections The settings sections.
 	 */
-	return (array) apply_filters( 'tml_admin_get_settings_sections', array(
-		'tml_settings_general' => array(
-			'title'    => __( 'General', 'theme-my-login' ),
-			'callback' => '__return_null',
-			'page'     => 'theme-my-login',
-		),
-		'tml_settings_login' => array(
-			'title'    => __( 'Log In' ),
-			'callback' => '__return_null',
-			'page'     => 'theme-my-login',
-		),
-		'tml_settings_registration' => array(
-			'title'    => __( 'Registration', 'theme-my-login' ),
-			'callback' => '__return_null',
-			'page'     => 'theme-my-login',
-		),
-		'tml_settings_slugs' => array(
-			'title'    => __( 'Slugs', 'theme-my-login' ),
-			'callback' => 'tml_admin_setting_callback_slugs_section',
-			'page'     => 'theme-my-login',
-		),
-	) );
+	return (array) apply_filters(
+		'tml_admin_get_settings_sections',
+		array(
+			'tml_settings_general'      => array(
+				'title'    => __( 'General', 'theme-my-login' ),
+				'callback' => '__return_null',
+				'page'     => 'theme-my-login',
+			),
+			'tml_settings_login'        => array(
+				'title'    => __( 'Log In' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated "Log In" string, not a TML-specific string.
+				'callback' => '__return_null',
+				'page'     => 'theme-my-login',
+			),
+			'tml_settings_registration' => array(
+				'title'    => __( 'Registration', 'theme-my-login' ),
+				'callback' => '__return_null',
+				'page'     => 'theme-my-login',
+			),
+			'tml_settings_slugs'        => array(
+				'title'    => __( 'Slugs', 'theme-my-login' ),
+				'callback' => 'tml_admin_setting_callback_slugs_section',
+				'page'     => 'theme-my-login',
+			),
+		)
+	);
 }
 
 /**
@@ -134,7 +137,7 @@ function tml_admin_get_settings_fields() {
 			'title'             => __( 'AJAX', 'theme-my-login' ),
 			'callback'          => 'tml_admin_setting_callback_checkbox_field',
 			'sanitize_callback' => 'sanitize_text_field',
-			'args' => array(
+			'args'              => array(
 				'label_for' => 'tml_ajax',
 				'label'     => __( 'Enable AJAX requests', 'theme-my-login' ),
 				'value'     => '1',
@@ -150,13 +153,13 @@ function tml_admin_get_settings_fields() {
 			'title'             => __( 'Login Type', 'theme-my-login' ),
 			'callback'          => 'tml_admin_setting_callback_radio_group_field',
 			'sanitize_callback' => 'sanitize_text_field',
-			'args' => array(
+			'args'              => array(
 				'label_for' => 'tml_login_type',
 				'legend'    => __( 'Login Type', 'theme-my-login' ),
 				'options'   => array(
-					'default'  => __( 'Default',       'theme-my-login' ),
+					'default'  => __( 'Default', 'theme-my-login' ),
 					'username' => __( 'Username only', 'theme-my-login' ),
-					'email'    => __( 'Email only',    'theme-my-login' ),
+					'email'    => __( 'Email only', 'theme-my-login' ),
 				),
 				'checked'   => get_site_option( 'tml_login_type', 'default' ),
 			),
@@ -170,22 +173,22 @@ function tml_admin_get_settings_fields() {
 			'title'             => __( 'Registration Type', 'theme-my-login' ),
 			'callback'          => 'tml_admin_setting_callback_radio_group_field',
 			'sanitize_callback' => 'sanitize_text_field',
-			'args' => array(
+			'args'              => array(
 				'label_for' => 'tml_registration_type',
 				'legend'    => __( 'Registration Type', 'theme-my-login' ),
 				'options'   => array(
-					'default'  => __( 'Default',    'theme-my-login' ),
-					'email'    => __( 'Email only', 'theme-my-login' ),
+					'default' => __( 'Default', 'theme-my-login' ),
+					'email'   => __( 'Email only', 'theme-my-login' ),
 				),
 				'checked'   => get_site_option( 'tml_registration_type', 'default' ),
 			),
 		),
 		// User passwords
-		'tml_user_passwords' => array(
+		'tml_user_passwords'    => array(
 			'title'             => __( 'Passwords', 'theme-my-login' ),
 			'callback'          => 'tml_admin_setting_callback_checkbox_field',
 			'sanitize_callback' => 'sanitize_text_field',
-			'args' => array(
+			'args'              => array(
 				'label_for' => 'tml_user_passwords',
 				'label'     => __( 'Allow users to set their own password', 'theme-my-login' ),
 				'value'     => '1',
@@ -193,11 +196,11 @@ function tml_admin_get_settings_fields() {
 			),
 		),
 		// Auto-login
-		'tml_auto_login' => array(
+		'tml_auto_login'        => array(
 			'title'             => __( 'Auto-Login', 'theme-my-login' ),
 			'callback'          => 'tml_admin_setting_callback_checkbox_field',
 			'sanitize_callback' => 'sanitize_text_field',
-			'args' => array(
+			'args'              => array(
 				'label_for' => 'tml_auto_login',
 				'label'     => __( 'Automatically log in users after registration', 'theme-my-login' ),
 				'value'     => '1',
@@ -219,12 +222,12 @@ function tml_admin_get_settings_fields() {
 			'title'             => $action->get_title(),
 			'callback'          => 'tml_admin_setting_callback_input_field',
 			'sanitize_callback' => 'sanitize_text_field',
-			'args' => array(
+			'args'              => array(
 				'label_for'   => $slug_option,
 				'value'       => get_site_option( $slug_option, $action->get_slug() ),
 				'attributes'  => array(
-					'checked' => true,
-					'class' => 'regular-text code',
+					'checked'  => true,
+					'class'    => 'regular-text code',
 					'required' => true,
 				),
 				'description' => sprintf( '<a href="%1$s">%1$s</a>', $action->get_url() ),
@@ -248,11 +251,11 @@ function tml_admin_get_settings_fields() {
  * @since 7.0.5
  */
 function tml_admin_setting_callback_slugs_section() {
-?>
+	?>
 
 <p><?php esc_html_e( 'The slugs defined here will be used to generate the URL to the corresponding action. You can see this URL below the slug field. If you would like to use pages for these actions, simply make sure the slug for the action below matches the slug of the page you would like to use for that action.', 'theme-my-login' ); ?></p>
 
-<?php
+	<?php
 }
 
 /**
@@ -272,43 +275,64 @@ function tml_admin_setting_callback_slugs_section() {
  * }
  */
 function tml_admin_setting_callback_input_field( $args ) {
-	$args = wp_parse_args( $args, array(
-		'label_for'   => '',
-		'value'       => '',
-		'description' => '',
-		'attributes'  => array(),
-		'input_type'  => 'text',
-		'input_class' => 'regular-text',
-	) );
+	$args = wp_parse_args(
+		$args,
+		array(
+			'label_for'   => '',
+			'value'       => '',
+			'description' => '',
+			'attributes'  => array(),
+			'input_type'  => 'text',
+			'input_class' => 'regular-text',
+		)
+	);
 
 	$attributes = is_array( $args['attributes'] ) ? array_filter( $args['attributes'] ) : array();
 
-	isset( $args['label_for'] ) && $attributes['name'] = $args['label_for'];
-	isset( $args['label_for'] ) && $attributes['id'] = $args['label_for'];
-	isset( $args['value'] ) && $attributes['value'] = $args['value'];
-	isset( $args['input_type'] ) && empty( $attributes['type'] ) && $attributes['type'] = $args['input_type'];
-	isset( $args['input_class'] ) && empty( $attributes['class'] ) && $attributes['class'] = $args['input_class'];
+	if ( isset( $args['label_for'] ) ) {
+		$attributes['name'] = $args['label_for'];
+		$attributes['id']   = $args['label_for'];
+	}
+	if ( isset( $args['value'] ) ) {
+		$attributes['value'] = $args['value'];
+	}
+	if ( isset( $args['input_type'] ) && empty( $attributes['type'] ) ) {
+		$attributes['type'] = $args['input_type'];
+	}
+	if ( isset( $args['input_class'] ) && empty( $attributes['class'] ) ) {
+		$attributes['class'] = $args['input_class'];
+	}
 
-	$attributes = array_map( function ( $key ) use ( $attributes ) {
-		return is_bool( $attributes[ $key ] ) ? esc_attr( $key ) : sprintf( "%s='%s'", esc_attr( $key ), esc_attr( $attributes[ $key ] ) );
-	}, array_keys( $attributes ) );
+	$attributes = array_map(
+		function ( $key ) use ( $attributes ) {
+			return is_bool( $attributes[ $key ] ) ? esc_attr( $key ) : sprintf( "%s='%s'", esc_attr( $key ), esc_attr( $attributes[ $key ] ) );
+		},
+		array_keys( $attributes )
+	);
 
-	usort( $attributes, function ( $a, $b ) {
-		$x = strpos( $a, '=' ) === false;
-		$y = strpos( $b, '=' ) === false;
-		if ( $x && !$y ) return 1;
-		if ( $y && !$x ) return -1;
-		return strcmp( $a, $b );
-	} );
-?>
+	usort(
+		$attributes,
+		function ( $a, $b ) {
+			$x = strpos( $a, '=' ) === false;
+			$y = strpos( $b, '=' ) === false;
+			if ( $x && ! $y ) {
+				return 1;
+			}
+			if ( $y && ! $x ) {
+				return -1;
+			}
+			return strcmp( $a, $b );
+		}
+	);
+	?>
 
-	<input <?php echo implode( ' ', $attributes ); ?>/>
+	<input <?php echo implode( ' ', $attributes ); /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- each attribute string is already built via esc_attr() above. */ ?>/>
 
 	<?php if ( ! empty( $args['description'] ) ) : ?>
-		<p class="description"><?php echo $args['description']; ?></p>
+		<p class="description"><?php echo wp_kses_post( $args['description'] ); ?></p>
 	<?php endif; ?>
 
-<?php
+	<?php
 }
 
 /**
@@ -327,22 +351,25 @@ function tml_admin_setting_callback_input_field( $args ) {
  * }
  */
 function tml_admin_setting_callback_checkbox_field( $args ) {
-	$args = wp_parse_args( $args, array(
-		'label_for'   => '',
-		'label'       => '',
-		'value'       => '1',
-		'checked'     => '',
-		'description' => '',
-	) );
-?>
+	$args = wp_parse_args(
+		$args,
+		array(
+			'label_for'   => '',
+			'label'       => '',
+			'value'       => '1',
+			'checked'     => '',
+			'description' => '',
+		)
+	);
+	?>
 
-	<input type="checkbox" name="<?php echo esc_attr( $args['label_for'] ); ?>" id="<?php echo esc_attr( $args['label_for'] ); ?>" value="<?php echo $args['value']; ?>" <?php checked( ! empty( $args['checked'] ) ); ?> /> <label for="<?php echo esc_attr( $args['label_for'] ); ?>"><?php echo esc_html( $args['label'] ); ?></label>
+	<input type="checkbox" name="<?php echo esc_attr( $args['label_for'] ); ?>" id="<?php echo esc_attr( $args['label_for'] ); ?>" value="<?php echo esc_attr( $args['value'] ); ?>" <?php checked( ! empty( $args['checked'] ) ); ?> /> <label for="<?php echo esc_attr( $args['label_for'] ); ?>"><?php echo esc_html( $args['label'] ); ?></label>
 
 	<?php if ( ! empty( $args['description'] ) ) : ?>
-		<p class="description"><?php echo $args['description']; ?></p>
+		<p class="description"><?php echo wp_kses_post( $args['description'] ); ?></p>
 	<?php endif; ?>
 
-<?php
+	<?php
 }
 
 /**
@@ -359,11 +386,14 @@ function tml_admin_setting_callback_checkbox_field( $args ) {
  * }
  */
 function tml_admin_setting_callback_checkbox_group_field( $args ) {
-	$args = wp_parse_args( $args, array(
-		'legend'      => '',
-		'options'     => array(),
-		'description' => '',
-	) );
+	$args = wp_parse_args(
+		$args,
+		array(
+			'legend'      => '',
+			'options'     => array(),
+			'description' => '',
+		)
+	);
 
 	$options = array();
 	foreach ( (array) $args['options'] as $option_name => $option ) {
@@ -375,18 +405,18 @@ function tml_admin_setting_callback_checkbox_group_field( $args ) {
 			esc_html( $option['label'] )
 		);
 	}
-?>
+	?>
 
 	<fieldset>
 		<legend class="screen-reader-text"><span><?php echo esc_html( $args['legend'] ); ?></span></legend>
-		<?php echo implode( "<br />\n", $options ); ?>
+		<?php echo implode( "<br />\n", $options ); /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- each $options entry is already built via esc_attr()/esc_html() above. */ ?>
 	</fieldset>
 
 	<?php if ( ! empty( $args['description'] ) ) : ?>
-		<p class="description"><?php echo $args['description']; ?></p>
+		<p class="description"><?php echo wp_kses_post( $args['description'] ); ?></p>
 	<?php endif; ?>
 
-<?php
+	<?php
 }
 
 /**
@@ -404,12 +434,15 @@ function tml_admin_setting_callback_checkbox_group_field( $args ) {
  * }
  */
 function tml_admin_setting_callback_dropdown_field( $args ) {
-	$args = wp_parse_args( $args, array(
-		'label_for'   => '',
-		'options'     => array(),
-		'selected'    => '',
-		'description' => '',
-	) );
+	$args = wp_parse_args(
+		$args,
+		array(
+			'label_for'   => '',
+			'options'     => array(),
+			'selected'    => '',
+			'description' => '',
+		)
+	);
 
 	$options = array();
 	foreach ( (array) $args['options'] as $value => $label ) {
@@ -420,17 +453,17 @@ function tml_admin_setting_callback_dropdown_field( $args ) {
 			esc_html( $label )
 		);
 	}
-?>
+	?>
 
 	<select name="<?php echo esc_attr( $args['label_for'] ); ?>" id="<?php echo esc_attr( $args['label_for'] ); ?>">
-		<?php echo implode( "<br />\n", $options ); ?>
+		<?php echo implode( "<br />\n", $options ); /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- each $options entry is already built via esc_attr()/esc_html() above. */ ?>
 	</select>
 
 	<?php if ( ! empty( $args['description'] ) ) : ?>
-		<p class="description"><?php echo $args['description']; ?></p>
+		<p class="description"><?php echo wp_kses_post( $args['description'] ); ?></p>
 	<?php endif; ?>
 
-<?php
+	<?php
 }
 
 /**
@@ -449,13 +482,16 @@ function tml_admin_setting_callback_dropdown_field( $args ) {
  * }
  */
 function tml_admin_setting_callback_radio_group_field( $args ) {
-	$args = wp_parse_args( $args, array(
-		'label_for'   => '',
-		'legend'      => '',
-		'options'     => array(),
-		'checked'     => '',
-		'description' => '',
-	) );
+	$args = wp_parse_args(
+		$args,
+		array(
+			'label_for'   => '',
+			'legend'      => '',
+			'options'     => array(),
+			'checked'     => '',
+			'description' => '',
+		)
+	);
 
 	$options = array();
 	foreach ( (array) $args['options'] as $value => $label ) {
@@ -467,18 +503,18 @@ function tml_admin_setting_callback_radio_group_field( $args ) {
 			esc_html( $label )
 		);
 	}
-?>
+	?>
 
 	<fieldset>
 		<legend class="screen-reader-text"><span><?php echo esc_html( $args['legend'] ); ?></span></legend>
-		<?php echo implode( "<br />\n", $options ); ?>
+		<?php echo implode( "<br />\n", $options ); /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- each $options entry is already built via esc_attr()/esc_html() above. */ ?>
 	</fieldset>
 
 	<?php if ( ! empty( $args['description'] ) ) : ?>
-		<p class="description"><?php echo $args['description']; ?></p>
+		<p class="description"><?php echo wp_kses_post( $args['description'] ); ?></p>
 	<?php endif; ?>
 
-<?php
+	<?php
 }
 
 /**
@@ -494,22 +530,26 @@ function tml_admin_setting_callback_radio_group_field( $args ) {
  * }
  */
 function tml_admin_setting_callback_license_key_field( $args ) {
-	$args = wp_parse_args( $args, array(
-		'label_for' => '',
-		'extension' => '',
-	) );
+	$args = wp_parse_args(
+		$args,
+		array(
+			'label_for' => '',
+			'extension' => '',
+		)
+	);
 
-	if ( ! $extension = tml_get_extension( $args['extension'] ) ) {
+	$extension = tml_get_extension( $args['extension'] );
+	if ( ! $extension ) {
 		return;
 	}
 
 	$license = $extension->get_license_key();
 	$status  = $extension->get_license_status();
 
-	if ( 'valid' == $status ) {
+	if ( 'valid' === $status ) {
 		$class = 'tml-license-valid';
 		$text  = __( 'Active', 'theme-my-login' );
-	} elseif ( 'invalid' == $status ) {
+	} elseif ( 'invalid' === $status ) {
 		$class = 'tml-license-invalid';
 		$text  = __( 'Invalid', 'theme-my-login' );
 	} else {
@@ -522,7 +562,7 @@ function tml_admin_setting_callback_license_key_field( $args ) {
 		esc_attr( $args['label_for'] ),
 		esc_attr( $license ),
 		esc_attr( $class ),
-		'valid' == $status ? 'readonly="readonly"' : ''
+		'valid' === $status ? 'readonly="readonly"' : ''
 	) . "\n";
 
 	submit_button(
@@ -533,7 +573,7 @@ function tml_admin_setting_callback_license_key_field( $args ) {
 		array(
 			'data-action'    => 'deactivate',
 			'data-extension' => $extension->get_name(),
-			'style'          => ( empty( $license ) || 'valid' != $status ) ? 'display: none;' : '',
+			'style'          => ( empty( $license ) || 'valid' !== $status ) ? 'display: none;' : '',
 		)
 	);
 
@@ -545,7 +585,7 @@ function tml_admin_setting_callback_license_key_field( $args ) {
 		array(
 			'data-action'    => 'activate',
 			'data-extension' => $extension->get_name(),
-			'style'          => ( empty( $license ) || 'valid' == $status ) ? 'display: none;' : '',
+			'style'          => ( empty( $license ) || 'valid' === $status ) ? 'display: none;' : '',
 		)
 	);
 
@@ -567,21 +607,24 @@ function tml_admin_setting_callback_license_key_field( $args ) {
 function tml_admin_settings_page() {
 	global $title, $plugin_page;
 
-	if ( 'theme-my-login' == $plugin_page ) {
+	if ( 'theme-my-login' === $plugin_page ) {
 		tml_flush_rewrite_rules();
 	}
 
 	settings_errors();
-?>
+	?>
 
 <div class="wrap">
-	<h1><?php echo esc_html( $title ) ?></h1>
+	<h1><?php echo esc_html( $title ); ?></h1>
 	<hr class="wp-header-end">
 
-	<form id="tml-settings" action="<?php echo is_network_admin()
+	<form id="tml-settings" action="
+	<?php
+	echo is_network_admin()
 		? 'edit.php?action=theme-my-login'
 		: 'options.php';
-	?>" method="post">
+	?>
+	" method="post">
 
 		<?php settings_fields( $plugin_page ); ?>
 
@@ -591,7 +634,7 @@ function tml_admin_settings_page() {
 	</form>
 </div>
 
-<?php
+	<?php
 }
 
 /**
@@ -605,9 +648,10 @@ function tml_admin_save_ms_settings() {
 		return;
 	}
 
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- the nonce action name below is derived from $option_page itself, so it must be read before check_admin_referer() can run; verified two lines down.
 	$option_page = ! empty( $_REQUEST['option_page'] ) ? $_REQUEST['option_page'] : '';
 
-	if ( empty( $option_page) || ! theme_my_login_admin()->has_page( $option_page ) ) {
+	if ( empty( $option_page ) || ! theme_my_login_admin()->has_page( $option_page ) ) {
 		return;
 	}
 
@@ -622,7 +666,8 @@ function tml_admin_save_ms_settings() {
 	if ( ! isset( $allowed_options[ $option_page ] ) ) {
 		wp_die(
 			sprintf(
-				__( '<strong>Error:</strong> The %s options page is not in the allowed options list.' ),
+				/* translators: %s: The options page name. */
+				__( '<strong>Error:</strong> The %s options page is not in the allowed options list.' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain, WordPress.Security.EscapeOutput.OutputNotEscaped -- reusing WP core's translated error string verbatim (see wp-admin/options.php); the dynamic value is already esc_html()'d below.
 				'<code>' . esc_html( $option_page ) . '</code>'
 			)
 		);
@@ -648,12 +693,12 @@ function tml_admin_save_ms_settings() {
 	tml_flush_rewrite_rules();
 
 	if ( ! count( get_settings_errors() ) ) {
-		add_settings_error( 'general', 'settings_updated', __( 'Settings saved.' ), 'updated' );
+		add_settings_error( 'general', 'settings_updated', __( 'Settings saved.' ), 'updated' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated "Settings saved." string, not a TML-specific string.
 	}
 	set_transient( 'settings_errors', get_settings_errors(), 30 );
 
 	$goback = add_query_arg( 'settings-updated', 'true', wp_get_referer() );
-	wp_redirect( $goback );
+	wp_safe_redirect( $goback );
 	exit;
 }
 
@@ -667,23 +712,27 @@ function tml_admin_save_ms_settings() {
 function tml_admin_add_settings_help_tabs( $screen ) {
 	global $plugin_page;
 
-	$help_tabs = $sidebar_links = array();
+	$help_tabs     = array();
+	$sidebar_links = array();
 
 	if ( empty( $plugin_page ) || ! theme_my_login_admin()->has_page( $plugin_page ) ) {
 		return;
 	}
 
 	// Core page
-	if ( 'theme-my-login' == $plugin_page ) {
+	if ( 'theme-my-login' === $plugin_page ) {
 		$help_tabs['overview'] = array(
 			'id'      => 'theme-my-login-overview',
-			'title'   => __( 'Overview' ),
-			'content' => '<p>' . implode( '</p><p>', array(
-				__( 'Welcome to Theme My Login!', 'theme-my-login' ),
-				__( 'Below, you can configure how you would like users to register and log in to your site.', 'theme-my-login' ),
-				__( 'Additionally, you can change the slugs that are used to generate the URLs that represent specific actions.', 'theme-my-login' ),
-				__( 'You must click the Save Changes button at the bottom of the screen for new settings to take effect.' ),
-			) ) . '</p>',
+			'title'   => __( 'Overview' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated "Overview" string, not a TML-specific string.
+			'content' => '<p>' . implode(
+				'</p><p>',
+				array(
+					__( 'Welcome to Theme My Login!', 'theme-my-login' ),
+					__( 'Below, you can configure how you would like users to register and log in to your site.', 'theme-my-login' ),
+					__( 'Additionally, you can change the slugs that are used to generate the URLs that represent specific actions.', 'theme-my-login' ),
+					__( 'You must click the Save Changes button at the bottom of the screen for new settings to take effect.' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated string (see wp-admin/options-general.php), not a TML-specific string.
+				)
+			) . '</p>',
 		);
 
 		$sidebar_links['documentation'] = array(
@@ -696,74 +745,91 @@ function tml_admin_add_settings_help_tabs( $screen ) {
 			'url'   => 'https://wordpress.org/support/plugin/theme-my-login',
 		);
 
-	// Licenses page
-	} elseif ( 'theme-my-login-licenses' == $plugin_page ) {
+		// Licenses page
+	} elseif ( 'theme-my-login-licenses' === $plugin_page ) {
 		$help_tabs['overview'] = array(
 			'id'      => 'theme-my-login-licenses-overview',
-			'title'   => __( 'Overview' ),
-			'content' => '<p>' . implode( '</p><p>', array(
-				__( 'When you purchase extensions for Theme My Login, you will enter your license keys on this page.', 'theme-my-login' ),
-				__( 'After you enter your license keys and click the Save Changes button at the bottom of the screen, you will see a new button next to each field with a license in it.', 'theme-my-login' ),
-				__( 'If you have not yet activated your license, this button will say "Activate". Click this button to activate your license.', 'theme-my-login' ),
-				__( 'If you have already activated your license, this button will say "Deactivate". Click this button to deactivate your license.', 'theme-my-login' ),
-			) ) . '</p>',
+			'title'   => __( 'Overview' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated "Overview" string, not a TML-specific string.
+			'content' => '<p>' . implode(
+				'</p><p>',
+				array(
+					__( 'When you purchase extensions for Theme My Login, you will enter your license keys on this page.', 'theme-my-login' ),
+					__( 'After you enter your license keys and click the Save Changes button at the bottom of the screen, you will see a new button next to each field with a license in it.', 'theme-my-login' ),
+					__( 'If you have not yet activated your license, this button will say "Activate". Click this button to activate your license.', 'theme-my-login' ),
+					__( 'If you have already activated your license, this button will say "Deactivate". Click this button to deactivate your license.', 'theme-my-login' ),
+				)
+			) . '</p>',
 		);
 
 		$sidebar_links['documentation'] = array(
 			'title' => __( 'View Documentation', 'theme-my-login' ),
 			'url'   => 'https://docs.thememylogin.com/article/59-how-do-i-install-an-extension',
 		);
-		$sidebar_links['support'] = array(
+		$sidebar_links['support']       = array(
 			'title' => __( 'Get Support', 'theme-my-login' ),
 			'url'   => 'https://thememylogin.com/support',
 		);
 
-	// Extensions page
-	} elseif ( 'theme-my-login-extensions' == $plugin_page ) {
+		// Extensions page
+	} elseif ( 'theme-my-login-extensions' === $plugin_page ) {
 		$help_tabs['overview'] = array(
 			'id'      => 'theme-my-login-extensions-overview',
-			'title'   => __( 'Overview' ),
-			'content' => '<p>' . implode( '</p><p>', array(
-				__( 'This page shows you all of the extensions available to purchase for Theme My Login.', 'theme-my-login' ),
-				__( 'Once you purchase an extension, you download it from your email receipt or your account page on our website. Then, you install it just like a normal WordPress plugin.', 'theme-my-login' ),
-			) ) . '</p>',
+			'title'   => __( 'Overview' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated "Overview" string, not a TML-specific string.
+			'content' => '<p>' . implode(
+				'</p><p>',
+				array(
+					__( 'This page shows you all of the extensions available to purchase for Theme My Login.', 'theme-my-login' ),
+					__( 'Once you purchase an extension, you download it from your email receipt or your account page on our website. Then, you install it just like a normal WordPress plugin.', 'theme-my-login' ),
+				)
+			) . '</p>',
 		);
 
 		$sidebar_links['documentation'] = array(
 			'title' => __( 'View Documentation', 'theme-my-login' ),
 			'url'   => 'https://docs.thememylogin.com/article/59-how-do-i-install-an-extension',
 		);
-		$sidebar_links['store'] = array(
+		$sidebar_links['store']         = array(
 			'title' => __( 'Go to the Extensions Store', 'theme-my-login' ),
 			'url'   => 'https://thememylogin.com/extensions',
 		);
-		$sidebar_links['account'] = array(
+		$sidebar_links['account']       = array(
 			'title' => __( 'View your Theme My Login account', 'theme-my-login' ),
 			'url'   => 'https://thememylogin.com/your-account',
 		);
 
-	// Extension page
-	} elseif ( $extension = tml_get_extension( $plugin_page ) ) {
+		// Extension page
+	} else {
+		$extension = tml_get_extension( $plugin_page );
+	}
+
+	if ( ! empty( $extension ) ) {
 		$help_tabs['overview'] = array(
 			'id'      => $plugin_page . '-overview',
-			'title'   => __( 'Overview' ),
-			'content' => '<p>' . implode( '</p><p>', array(
-				sprintf(
-					__( 'On this page, you can configure the settings for the Theme My Login %s extension.', 'theme-my-login' ),
-					$extension->get_title()
-				),
-				__( 'You must click the Save Changes button at the bottom of the screen for new settings to take effect.' ),
-			) ) . '</p>',
+			'title'   => __( 'Overview' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated "Overview" string, not a TML-specific string.
+			'content' => '<p>' . implode(
+				'</p><p>',
+				array(
+					sprintf(
+						/* translators: %s: The extension title. */
+						__( 'On this page, you can configure the settings for the Theme My Login %s extension.', 'theme-my-login' ),
+						$extension->get_title()
+					),
+					// phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated string (see wp-admin/options-general.php), not a TML-specific string.
+					__( 'You must click the Save Changes button at the bottom of the screen for new settings to take effect.' ),
+				)
+			) . '</p>',
 		);
 
-		if ( $documentation_url = $extension->get_documentation_url() ) {
+		$documentation_url = $extension->get_documentation_url();
+		if ( $documentation_url ) {
 			$sidebar_links['documentation'] = array(
 				'title' => __( 'View Documentation', 'theme-my-login' ),
 				'url'   => $documentation_url,
 			);
 		}
 
-		if ( $support_url = $extension->get_support_url() ) {
+		$support_url = $extension->get_support_url();
+		if ( $support_url ) {
 			$sidebar_links['support'] = array(
 				'title' => __( 'Get Support', 'theme-my-login' ),
 				'url'   => $support_url,
@@ -788,9 +854,10 @@ function tml_admin_add_settings_help_tabs( $screen ) {
 
 	// Add the sidebar links
 	if ( ! empty( $sidebar_links ) ) {
-		$sidebar_content = '<p><strong>' . __( 'For more information:' ) . '</strong></p>';
+		$sidebar_content = '<p><strong>' . __( 'For more information:' ) . '</strong></p>'; // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated "For more information:" string, not a TML-specific string.
 		foreach ( $sidebar_links as $sidebar_link ) {
-			$sidebar_content .= sprintf( '<p><a href="%s">%s</a></p>',
+			$sidebar_content .= sprintf(
+				'<p><a href="%s">%s</a></p>',
 				$sidebar_link['url'],
 				$sidebar_link['title']
 			);

--- a/src/includes/actions.php
+++ b/src/includes/actions.php
@@ -774,7 +774,8 @@ function tml_password_reset_handler() {
 
 	if ( isset( $_COOKIE[ $rp_cookie ] ) && 0 < strpos( $_COOKIE[ $rp_cookie ], ':' ) ) {
 		list( $rp_login, $rp_key ) = explode( ':', wp_unslash( $_COOKIE[ $rp_cookie ] ), 2 );
-		$user                      = check_password_reset_key( $rp_key, $rp_login );
+
+		$user = check_password_reset_key( $rp_key, $rp_login );
 		if ( isset( $_POST['pass1'] ) && ! hash_equals( $rp_key, $_POST['rp_key'] ) ) {
 			$user = false;
 		}

--- a/src/includes/actions.php
+++ b/src/includes/actions.php
@@ -14,77 +14,102 @@
  */
 function tml_register_default_actions() {
 
+	// phpcs:disable WordPress.WP.I18n.MissingArgDomain -- these action titles/labels intentionally reuse WP core's translated wp-login.php strings verbatim, not TML-specific strings.
+
 	// Dashboard
-	tml_register_action( 'dashboard', array(
-		'title'              => __( 'Dashboard' ),
-		'slug'               => 'dashboard',
-		'callback'           => 'tml_dashboard_handler',
-		'show_on_forms'      => false,
-		'show_nav_menu_item' => is_user_logged_in(),
-	) );
+	tml_register_action(
+		'dashboard',
+		array(
+			'title'              => __( 'Dashboard' ),
+			'slug'               => 'dashboard',
+			'callback'           => 'tml_dashboard_handler',
+			'show_on_forms'      => false,
+			'show_nav_menu_item' => is_user_logged_in(),
+		)
+	);
 
 	// Login
-	tml_register_action( 'login', array(
-		'title'              => isset( $_GET['checkemail'] ) ? __( 'Check your email' ) : __( 'Log In' ),
-		'slug'               => 'login',
-		'callback'           => 'tml_login_handler',
-		'ajax_callback'      => 'tml_login_handler',
-		'show_on_forms'      => __( 'Log in' ),
-		'show_nav_menu_item' => ! is_user_logged_in(),
-	) );
+	tml_register_action(
+		'login',
+		array(
+			'title'              => isset( $_GET['checkemail'] ) ? __( 'Check your email' ) : __( 'Log In' ), // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only: just picks a display title, not processed/acted on.
+			'slug'               => 'login',
+			'callback'           => 'tml_login_handler',
+			'ajax_callback'      => 'tml_login_handler',
+			'show_on_forms'      => __( 'Log in' ),
+			'show_nav_menu_item' => ! is_user_logged_in(),
+		)
+	);
 
 	// Logout
-	tml_register_action( 'logout', array(
-		'title'              => __( 'Log Out' ),
-		'slug'               => 'logout',
-		'callback'           => 'tml_logout_handler',
-		'show_on_forms'      => false,
-		'show_in_widget'     => false,
-		'show_nav_menu_item' => is_user_logged_in(),
-	) );
+	tml_register_action(
+		'logout',
+		array(
+			'title'              => __( 'Log Out' ),
+			'slug'               => 'logout',
+			'callback'           => 'tml_logout_handler',
+			'show_on_forms'      => false,
+			'show_in_widget'     => false,
+			'show_nav_menu_item' => is_user_logged_in(),
+		)
+	);
 
 	// Register
-	tml_register_action( 'register', array(
-		'title'              => __( 'Register' ),
-		'slug'               => 'register',
-		'callback'           => 'tml_registration_handler',
-		'ajax_callback'      => 'tml_registration_handler',
-		'show_on_forms'      => (bool) get_option( 'users_can_register' ),
-		'show_nav_menu_item' => ! is_user_logged_in(),
-	) );
+	tml_register_action(
+		'register',
+		array(
+			'title'              => __( 'Register' ),
+			'slug'               => 'register',
+			'callback'           => 'tml_registration_handler',
+			'ajax_callback'      => 'tml_registration_handler',
+			'show_on_forms'      => (bool) get_option( 'users_can_register' ),
+			'show_nav_menu_item' => ! is_user_logged_in(),
+		)
+	);
 
 	// Lost Password
-	tml_register_action( 'lostpassword', array(
-		'title'             => __( 'Lost Password' ),
-		'slug'              => 'lostpassword',
-		'callback'          => 'tml_lost_password_handler',
-		'ajax_callback'     => 'tml_lost_password_handler',
-		'network'           => true,
-		'show_on_forms'     => __( 'Lost your password?' ),
-		'show_in_nav_menus' => false,
-	) );
+	tml_register_action(
+		'lostpassword',
+		array(
+			'title'             => __( 'Lost Password' ),
+			'slug'              => 'lostpassword',
+			'callback'          => 'tml_lost_password_handler',
+			'ajax_callback'     => 'tml_lost_password_handler',
+			'network'           => true,
+			'show_on_forms'     => __( 'Lost your password?' ),
+			'show_in_nav_menus' => false,
+		)
+	);
 
 	// Reset Password
-	tml_register_action( 'resetpass', array(
-		'title'             => __( 'Reset Password' ),
-		'slug'              => 'resetpass',
-		'callback'          => 'tml_password_reset_handler',
-		'network'           => true,
-		'show_on_forms'     => false,
-		'show_in_widget'    => false,
-		'show_in_nav_menus' => false,
-	) );
+	tml_register_action(
+		'resetpass',
+		array(
+			'title'             => __( 'Reset Password' ),
+			'slug'              => 'resetpass',
+			'callback'          => 'tml_password_reset_handler',
+			'network'           => true,
+			'show_on_forms'     => false,
+			'show_in_widget'    => false,
+			'show_in_nav_menus' => false,
+		)
+	);
+
+	// phpcs:enable WordPress.WP.I18n.MissingArgDomain
 
 	// Confirm Action (Data Requests)
-	tml_register_action( 'confirmaction', array(
-		'title'                 => __( 'Your Data Request', 'theme-my-login' ),
-		'slug'                  => 'confirmaction',
-		'callback'              => 'tml_confirmaction_handler',
-		'show_on_forms'         => false,
-		'show_in_widget'        => false,
-		'show_in_nav_menus'     => false,
-		'show_in_slug_settings' => false,
-	) );
+	tml_register_action(
+		'confirmaction',
+		array(
+			'title'                 => __( 'Your Data Request', 'theme-my-login' ),
+			'slug'                  => 'confirmaction',
+			'callback'              => 'tml_confirmaction_handler',
+			'show_on_forms'         => false,
+			'show_in_widget'        => false,
+			'show_in_nav_menus'     => false,
+			'show_in_slug_settings' => false,
+		)
+	);
 }
 
 /**
@@ -104,7 +129,8 @@ function tml_register_action( $action, $args = array() ) {
 		$action = new Theme_My_Login_Action( $action, $args );
 	}
 
-	if ( $slug = get_site_option( 'tml_' . $action->get_name() . '_slug' ) ) {
+	$slug = get_site_option( 'tml_' . $action->get_name() . '_slug' );
+	if ( $slug ) {
 		$action->set_slug( $slug );
 	}
 
@@ -194,7 +220,7 @@ function tml_is_action( $action = '' ) {
 	if ( $current_action && array_key_exists( $current_action->get_name(), tml_get_actions() ) ) {
 		if ( empty( $action ) ) {
 			$is_action = true;
-		} elseif ( $action == $current_action->get_name() ) {
+		} elseif ( $action === $current_action->get_name() ) {
 			$is_action = true;
 		}
 	}
@@ -219,7 +245,8 @@ function tml_is_action( $action = '' ) {
  * @return string The action title.
  */
 function tml_get_action_title( $action = '' ) {
-	if ( ! $action = tml_get_action( $action ) ) {
+	$action = tml_get_action( $action );
+	if ( ! $action ) {
 		return;
 	}
 	return $action->get_title();
@@ -234,7 +261,8 @@ function tml_get_action_title( $action = '' ) {
  * @return string The action slug.
  */
 function tml_get_action_slug( $action = '' ) {
-	if ( ! $action = tml_get_action( $action ) ) {
+	$action = tml_get_action( $action );
+	if ( ! $action ) {
 		return;
 	}
 	return $action->get_slug();
@@ -251,7 +279,8 @@ function tml_get_action_slug( $action = '' ) {
  * @return string The action URL.
  */
 function tml_get_action_url( $action = '', $scheme = 'login', $network = null ) {
-	if ( ! $action = tml_get_action( $action ) ) {
+	$action = tml_get_action( $action );
+	if ( ! $action ) {
 		return;
 	}
 	return $action->get_url( $scheme, $network );
@@ -267,23 +296,27 @@ function tml_get_action_url( $action = '', $scheme = 'login', $network = null ) 
  */
 function tml_action_has_page( $action = '' ) {
 
-	if ( ! $action = tml_get_action( $action ) ) {
+	$action = tml_get_action( $action );
+	if ( ! $action ) {
 		return false;
 	}
 
 	$pages = wp_cache_get( 'pages', 'theme-my-login' );
 	if ( false === $pages ) {
-		$pages = get_posts( [
-			'post_name__in'          => array_map( 'tml_get_action_slug', tml_get_actions() ),
-			'post_type'              => 'page',
-			'nopaging'               => true,
-			'update_post_meta_cache' => false,
-			'update_post_term_cache' => false,
-		] );
+		$pages = get_posts(
+			array(
+				'post_name__in'          => array_map( 'tml_get_action_slug', tml_get_actions() ),
+				'post_type'              => 'page',
+				'nopaging'               => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+			)
+		);
 		wp_cache_set( 'pages', $pages, 'theme-my-login' );
 	}
 
-	if ( $pages = wp_list_filter( $pages, [ 'post_name' => $action->get_slug() ] ) ) {
+	$pages = wp_list_filter( $pages, array( 'post_name' => $action->get_slug() ) );
+	if ( $pages ) {
 		return reset( $pages );
 	}
 
@@ -302,7 +335,7 @@ function tml_action_handler() {
 
 	// Redirect to https login if forced to use SSL
 	if ( force_ssl_admin() && ! is_ssl() ) {
-		if ( 0 === strpos($_SERVER['REQUEST_URI'], 'http') ) {
+		if ( 0 === strpos( $_SERVER['REQUEST_URI'], 'http' ) ) {
 			wp_safe_redirect( set_url_scheme( $_SERVER['REQUEST_URI'], 'https' ) );
 			exit();
 		} else {
@@ -312,24 +345,27 @@ function tml_action_handler() {
 	}
 
 	// Redirect other actions from the login action
-	if ( $action = tml_get_request_value( 'action' ) ) {
-		if ( tml_is_action( 'login' ) && 'login' != $action ) {
+	$action = tml_get_request_value( 'action' );
+	if ( $action ) {
+		if ( tml_is_action( 'login' ) && 'login' !== $action ) {
 			// Fix some alias actions
-			if ( 'retrievepassword' == $action ) {
+			if ( 'retrievepassword' === $action ) {
 				$action = 'lostpassword';
-			} elseif ( 'rp' == $action ) {
+			} elseif ( 'rp' === $action ) {
 				$action = 'resetpass';
 			}
 
 			// Get the action URL
-			if ( $url = tml_get_action_url( $action ) ) {
+			$url = tml_get_action_url( $action );
+			if ( $url ) {
 				// Add the query string to the URL
-				if ( $query = parse_url( $_SERVER['REQUEST_URI'], PHP_URL_QUERY ) ) {
+				$query = wp_parse_url( $_SERVER['REQUEST_URI'], PHP_URL_QUERY );
+				if ( $query ) {
 					parse_str( $query, $args );
 					unset( $args['action'] );
 					$url = add_query_arg( array_map( 'rawurlencode', $args ), $url );
 				}
-				wp_redirect( $url );
+				wp_safe_redirect( $url );
 				exit;
 			}
 		}
@@ -338,18 +374,22 @@ function tml_action_handler() {
 	nocache_headers();
 
 	// Set a test cookie to test if cookies are enabled
-	$secure = ( 'https' === parse_url( wp_login_url(), PHP_URL_SCHEME ) );
+	$secure = ( 'https' === wp_parse_url( wp_login_url(), PHP_URL_SCHEME ) );
 	setcookie( TEST_COOKIE, 'WP Cookie check', 0, COOKIEPATH, COOKIE_DOMAIN, $secure );
-	if ( SITECOOKIEPATH != COOKIEPATH ) {
+	if ( SITECOOKIEPATH !== COOKIEPATH ) {
 		setcookie( TEST_COOKIE, 'WP Cookie check', 0, SITECOOKIEPATH, COOKIE_DOMAIN, $secure );
 	}
 
 	// Add the testcookie field to the login form
-	tml_add_form_field( 'login', 'testcookie', array(
-		'type'     => 'hidden',
-		'value'    => 1,
-		'priority' => 30,
-	) );
+	tml_add_form_field(
+		'login',
+		'testcookie',
+		array(
+			'type'     => 'hidden',
+			'value'    => 1,
+			'priority' => 30,
+		)
+	);
 
 	/** This action is documented in wp-login.php */
 	do_action( 'login_init' );
@@ -381,7 +421,7 @@ function tml_action_handler() {
  */
 function tml_dashboard_handler() {
 	if ( ! is_user_logged_in() ) {
-		wp_redirect( wp_login_url( $_SERVER['REQUEST_URI'] ) );
+		wp_safe_redirect( wp_login_url( $_SERVER['REQUEST_URI'] ) );
 		exit;
 	}
 }
@@ -392,8 +432,9 @@ function tml_dashboard_handler() {
  * @since 7.0
  */
 function tml_login_handler() {
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing -- mirrors wp-login.php's own login-form processing, which authenticates via wp_signon()/credentials rather than a nonce.
 
-	$errors = new WP_Error;
+	$errors = new WP_Error();
 
 	$secure_cookie = '';
 
@@ -430,17 +471,21 @@ function tml_login_handler() {
 
 	if ( empty( $_COOKIE[ LOGGED_IN_COOKIE ] ) ) {
 		if ( headers_sent() ) {
-			$user = new WP_Error( 'test_cookie', sprintf(
-					__( '<strong>Error:</strong> Cookies are blocked due to unexpected output. For help, please see <a href="%1$s">this documentation</a> or try the <a href="%2$s">support forums</a>.' ),
-					__( 'https://wordpress.org/support/article/cookies/' ),
-					__( 'https://wordpress.org/support/forums/' )
+			$user = new WP_Error(
+				'test_cookie',
+				sprintf(
+					__( '<strong>Error:</strong> Cookies are blocked due to unexpected output. For help, please see <a href="%1$s">this documentation</a> or try the <a href="%2$s">support forums</a>.' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain, WordPress.WP.I18n.MissingTranslatorsComment -- reusing WP core's translated wp-login.php string verbatim, not a TML-specific string; no translators comment since it never enters TML's own .pot.
+					__( 'https://developer.wordpress.org/advanced-administration/wordpress/cookies/' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated wp-login.php string verbatim, not a TML-specific string.
+					__( 'https://wordpress.org/support/forums/' ) // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated wp-login.php string verbatim, not a TML-specific string.
 				)
 			);
 		} elseif ( isset( $_POST['testcookie'] ) && empty( $_COOKIE[ TEST_COOKIE ] ) ) {
 			// If cookies are disabled we can't log in even with a valid user+pass
-			$user = new WP_Error( 'test_cookie', sprintf(
-					__( '<strong>Error:</strong> Cookies are blocked or not supported by your browser. You must <a href="%s">enable cookies</a> to use WordPress.' ),
-					__( 'https://wordpress.org/support/article/cookies#enable-cookies-your-browser' )
+			$user = new WP_Error(
+				'test_cookie',
+				sprintf(
+					__( '<strong>Error:</strong> Cookies are blocked or not supported by your browser. You must <a href="%s">enable cookies</a> to use WordPress.' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain, WordPress.WP.I18n.MissingTranslatorsComment -- reusing WP core's translated wp-login.php string verbatim, not a TML-specific string; no translators comment since it never enters TML's own .pot.
+					__( 'https://developer.wordpress.org/advanced-administration/wordpress/cookies/#enable-cookies-in-your-browser' ) // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated wp-login.php string verbatim, not a TML-specific string.
 				)
 			);
 		}
@@ -450,7 +495,7 @@ function tml_login_handler() {
 
 	if ( ! is_wp_error( $user ) && ! $reauth ) {
 
-		if ( ( empty( $redirect_to ) || 'wp-admin/' == $redirect_to || admin_url() == $redirect_to ) ) {
+		if ( ( empty( $redirect_to ) || 'wp-admin/' === $redirect_to || admin_url() === $redirect_to ) ) {
 
 			// If the user doesn't belong to a blog, send them to user admin. If the user can't edit posts, send them to their profile.
 			if ( is_multisite() && ! get_active_blog_for_user( $user->ID ) && ! is_super_admin( $user->ID ) ) {
@@ -468,19 +513,24 @@ function tml_login_handler() {
 			}
 
 			if ( tml_is_ajax_request() ) {
-				tml_send_ajax_success( array(
-					'redirect' => $redirect_to,
-				) );
+				tml_send_ajax_success(
+					array(
+						'redirect' => $redirect_to,
+					)
+				);
 			} else {
+				// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- matches wp-login.php's own use of plain wp_redirect() here; $redirect_to is always internally computed by this point (admin_url()/user_admin_url()/tml_get_action_url()/home_url()), never raw user input.
 				wp_redirect( $redirect_to );
 				exit;
 			}
 		}
 
 		if ( tml_is_ajax_request() ) {
-			tml_send_ajax_success( array(
-				'redirect' => tml_validate_redirect( $redirect_to ),
-			) );
+			tml_send_ajax_success(
+				array(
+					'redirect' => tml_validate_redirect( $redirect_to ),
+				)
+			);
 		} else {
 			wp_safe_redirect( $redirect_to );
 			exit;
@@ -491,36 +541,37 @@ function tml_login_handler() {
 
 	// Clear errors if loggedout is set.
 	if ( ! empty( $_GET['loggedout'] ) || $reauth ) {
-		$errors = new WP_Error;
+		$errors = new WP_Error();
 	}
 
 	if ( empty( $_POST ) && $errors->get_error_codes() === array( 'empty_username', 'empty_password' ) ) {
-		$errors = new WP_Error;
+		$errors = new WP_Error();
 	}
 
 	// Some parts of this script use the main login form to display a message
-	if ( isset( $_GET['loggedout'] ) && true == $_GET['loggedout'] ) {
+	// phpcs:disable WordPress.WP.I18n.MissingArgDomain, WordPress.WP.I18n.MissingTranslatorsComment -- these messages intentionally reuse WP core's translated wp-login.php strings verbatim, not TML-specific strings; no translators comments since they never enter TML's own .pot.
+	if ( isset( $_GET['loggedout'] ) && $_GET['loggedout'] ) {
 		$errors->add( 'loggedout', __( 'You are now logged out.' ), 'message' );
 
-	} elseif ( isset( $_GET['registration'] ) && 'disabled' == $_GET['registration'] ) {
+	} elseif ( isset( $_GET['registration'] ) && 'disabled' === $_GET['registration'] ) {
 		$errors->add( 'registerdisabled', __( '<strong>Error:</strong> User registration is currently not allowed.' ) );
 
-	} elseif ( isset( $_GET['checkemail'] ) && 'confirm' == $_GET['checkemail'] ) {
-		$errors->add( 'confirm', sprintf( __( 'Check your email for the confirmation link, then visit the <a href="%s">login page</a>.' ), wp_login_url() ) , 'message' );
+	} elseif ( isset( $_GET['checkemail'] ) && 'confirm' === $_GET['checkemail'] ) {
+		$errors->add( 'confirm', sprintf( __( 'Check your email for the confirmation link, then visit the <a href="%s">login page</a>.' ), wp_login_url() ), 'message' );
 
-	} elseif ( isset( $_GET['checkemail'] ) && 'registered' == $_GET['checkemail'] ) {
+	} elseif ( isset( $_GET['checkemail'] ) && 'registered' === $_GET['checkemail'] ) {
 		if ( tml_allow_user_passwords() ) {
 			$errors->add( 'registered', __( 'Registration complete. You may now log in.', 'theme-my-login' ), 'message' );
 		} else {
 			$errors->add( 'registered', sprintf( __( 'Registration complete. Please check your email, then visit the <a href="%s">login page</a>.' ), wp_login_url() ), 'message' );
 		}
-
-	} elseif ( isset( $_GET['resetpass'] ) && 'complete' == $_GET['resetpass'] ) {
+	} elseif ( isset( $_GET['resetpass'] ) && 'complete' === $_GET['resetpass'] ) {
 		$errors->add( 'password_reset', __( 'Your password has been reset.' ), 'message' );
 
 	} elseif ( strpos( $redirect_to, 'about.php?updated' ) ) {
 		$errors->add( 'updated', __( '<strong>You have successfully updated WordPress!</strong> Please log back in to see what&#8217;s new.' ), 'message' );
 	}
+	// phpcs:enable WordPress.WP.I18n.MissingArgDomain
 
 	/** This filter is documented in wp-login.php */
 	$errors = apply_filters( 'wp_login_errors', $errors, $redirect_to );
@@ -533,10 +584,13 @@ function tml_login_handler() {
 	}
 
 	if ( tml_is_ajax_request() ) {
-		tml_send_ajax_error( array(
-			'errors' => tml_get_form()->render_errors(),
-		) );
+		tml_send_ajax_error(
+			array(
+				'errors' => tml_get_form()->render_errors(),
+			)
+		);
 	}
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing
 }
 
 /**
@@ -579,22 +633,29 @@ function tml_logout_handler() {
  * @since 7.0
  */
 function tml_registration_handler() {
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing -- mirrors wp-login.php's own registration-form processing (register_new_user()), which is a public unauthenticated form with no nonce.
 
 	if ( is_multisite() ) {
 		/** This filter is documented in wp-login.php */
 		$signup_location = apply_filters( 'wp_signup_location', network_site_url( 'wp-signup.php' ) );
 
+		// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- matches wp-login.php's own use of plain wp_redirect() here; $signup_location is always network_site_url()-derived, never raw user input.
 		wp_redirect( $signup_location );
 		exit;
 	}
 
 	if ( ! get_option( 'users_can_register' ) ) {
 		if ( tml_is_ajax_request() ) {
+			// phpcs:disable WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated wp-login.php string verbatim, not a TML-specific string.
 			tml_add_error( 'registerdisabled', __( '<strong>Error:</strong> User registration is currently not allowed.' ) );
-			tml_send_ajax_error( array(
-				'errors' => tml_get_form()->render_errors(),
-			) );
+			// phpcs:enable WordPress.WP.I18n.MissingArgDomain
+			tml_send_ajax_error(
+				array(
+					'errors' => tml_get_form()->render_errors(),
+				)
+			);
 		} else {
+			// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- matches wp-login.php's own use of plain wp_redirect() here; target is always site_url()-derived, never raw user input.
 			wp_redirect( site_url( 'wp-login.php?registration=disabled' ) );
 			exit;
 		}
@@ -603,7 +664,7 @@ function tml_registration_handler() {
 	if ( tml_is_post_request() ) {
 		$user_login = tml_get_request_value( 'user_login', 'post' );
 		$user_email = tml_get_request_value( 'user_email', 'post' );
-		$user_id = register_new_user( $user_login, $user_email );
+		$user_id    = register_new_user( $user_login, $user_email );
 		if ( ! is_wp_error( $user_id ) ) {
 			$redirect_to = ! empty( $_POST['redirect_to'] ) ? $_POST['redirect_to'] : site_url( 'wp-login.php?checkemail=registered' );
 
@@ -618,9 +679,11 @@ function tml_registration_handler() {
 			$redirect_to = apply_filters( 'tml_registration_redirect', $redirect_to, get_userdata( $user_id ) );
 
 			if ( tml_is_ajax_request() ) {
-				wp_send_json_success( array(
-					'redirect' => tml_validate_redirect( $redirect_to ),
-				) );
+				wp_send_json_success(
+					array(
+						'redirect' => tml_validate_redirect( $redirect_to ),
+					)
+				);
 			} else {
 				wp_safe_redirect( $redirect_to );
 				exit;
@@ -628,12 +691,15 @@ function tml_registration_handler() {
 		} else {
 			tml_set_errors( $user_id );
 			if ( tml_is_ajax_request() ) {
-				tml_send_ajax_error( array(
-					'errors' => tml_get_form()->render_errors(),
-				) );
+				tml_send_ajax_error(
+					array(
+						'errors' => tml_get_form()->render_errors(),
+					)
+				);
 			}
 		}
 	}
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing
 }
 
 /**
@@ -642,15 +708,20 @@ function tml_registration_handler() {
  * @since 7.0
  */
 function tml_lost_password_handler() {
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended -- mirrors wp-login.php's own lostpassword-form processing, which is a public unauthenticated form with no nonce.
 
 	if ( tml_is_post_request() ) {
 		$errors = retrieve_password();
 		if ( ! is_wp_error( $errors ) ) {
 			if ( tml_is_ajax_request() ) {
+				// phpcs:disable WordPress.WP.I18n.MissingArgDomain, WordPress.WP.I18n.MissingTranslatorsComment -- reusing WP core's translated wp-login.php string verbatim, not a TML-specific string; no translators comment since it never enters TML's own .pot.
 				tml_add_error( 'confirm', sprintf( __( 'Check your email for the confirmation link, then visit the <a href="%s">login page</a>.' ), wp_login_url() ), 'message' );
-				tml_send_ajax_success( array(
-					'notice' => tml_get_form()->render_errors(),
-				) );
+				// phpcs:enable WordPress.WP.I18n.MissingArgDomain, WordPress.WP.I18n.MissingTranslatorsComment
+				tml_send_ajax_success(
+					array(
+						'notice' => tml_get_form()->render_errors(),
+					)
+				);
 			} else {
 				$redirect_to = ! empty( $_REQUEST['redirect_to'] ) ? $_REQUEST['redirect_to'] : site_url( 'wp-login.php?checkemail=confirm' );
 				wp_safe_redirect( $redirect_to );
@@ -659,23 +730,28 @@ function tml_lost_password_handler() {
 		} else {
 			tml_set_errors( $errors );
 			if ( tml_is_ajax_request() ) {
-				tml_send_ajax_error( array(
-					'errors' => tml_get_form()->render_errors(),
-				) );
+				tml_send_ajax_error(
+					array(
+						'errors' => tml_get_form()->render_errors(),
+					)
+				);
 			}
 		}
 	}
 
 	if ( isset( $_REQUEST['error'] ) ) {
-		if ( 'invalidkey' == $_REQUEST['error'] ) {
+		// phpcs:disable WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated wp-login.php strings verbatim, not TML-specific strings.
+		if ( 'invalidkey' === $_REQUEST['error'] ) {
 			tml_add_error( 'invalidkey', __( '<strong>Error:</strong> Your password reset link appears to be invalid. Please request a new link below.' ) );
-		} elseif ( 'expiredkey' == $_REQUEST['error'] ) {
+		} elseif ( 'expiredkey' === $_REQUEST['error'] ) {
 			tml_add_error( 'expiredkey', __( '<strong>Error:</strong> Your password reset link has expired. Please request a new link below.' ) );
 		}
+		// phpcs:enable WordPress.WP.I18n.MissingArgDomain
 	}
 
 	/** This filter is documented in wp-login.php */
 	do_action( 'lost_password', tml_get_errors() );
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended
 }
 
 /**
@@ -684,9 +760,10 @@ function tml_lost_password_handler() {
  * @since 7.0
  */
 function tml_password_reset_handler() {
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing -- mirrors wp-login.php's own resetpass-form processing, which is secured by the rp_key/rp_login cookie/hash rather than a nonce.
 
 	list( $rp_path ) = explode( '?', wp_unslash( $_SERVER['REQUEST_URI'] ) );
-	$rp_cookie = 'wp-resetpass-' . COOKIEHASH;
+	$rp_cookie       = 'wp-resetpass-' . COOKIEHASH;
 
 	if ( isset( $_GET['key'] ) && isset( $_GET['login'] ) ) {
 		$value = sprintf( '%s:%s', wp_unslash( $_GET['login'] ), wp_unslash( $_GET['key'] ) );
@@ -697,7 +774,7 @@ function tml_password_reset_handler() {
 
 	if ( isset( $_COOKIE[ $rp_cookie ] ) && 0 < strpos( $_COOKIE[ $rp_cookie ], ':' ) ) {
 		list( $rp_login, $rp_key ) = explode( ':', wp_unslash( $_COOKIE[ $rp_cookie ] ), 2 );
-		$user = check_password_reset_key( $rp_key, $rp_login );
+		$user                      = check_password_reset_key( $rp_key, $rp_login );
 		if ( isset( $_POST['pass1'] ) && ! hash_equals( $rp_key, $_POST['rp_key'] ) ) {
 			$user = false;
 		}
@@ -707,15 +784,19 @@ function tml_password_reset_handler() {
 
 	if ( ! $user || is_wp_error( $user ) ) {
 		setcookie( $rp_cookie, ' ', time() - YEAR_IN_SECONDS, $rp_path, COOKIE_DOMAIN, is_ssl(), true );
+		// phpcs:disable WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- matches wp-login.php's own use of plain wp_redirect() here; target is always a hardcoded site_url() string, never raw user input.
 		if ( $user && $user->get_error_code() === 'expired_key' ) {
 			wp_redirect( site_url( 'wp-login.php?action=lostpassword&error=expiredkey' ) );
 		} else {
 			wp_redirect( site_url( 'wp-login.php?action=lostpassword&error=invalidkey' ) );
 		}
+		// phpcs:enable WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
 		exit;
 	}
 
-	$errors = new WP_Error;
+	$errors = new WP_Error();
+
+	// phpcs:disable WordPress.WP.I18n.MissingArgDomain -- these messages intentionally reuse WP core's translated wp-login.php strings verbatim, not TML-specific strings.
 
 	// Check if password is one or all empty spaces.
 	if ( ! empty( $_POST['pass1'] ) ) {
@@ -731,17 +812,22 @@ function tml_password_reset_handler() {
 		$errors->add( 'password_reset_mismatch', __( '<strong>Error:</strong> The passwords do not match.' ) );
 	}
 
+	// phpcs:enable WordPress.WP.I18n.MissingArgDomain
+
 	/** This action is documented in wp-login.php */
 	do_action( 'validate_password_reset', $errors, $user );
 
 	if ( ( ! $errors->has_errors() ) && isset( $_POST['pass1'] ) && ! empty( $_POST['pass1'] ) ) {
 		reset_password( $user, $_POST['pass1'] );
 		setcookie( $rp_cookie, ' ', time() - YEAR_IN_SECONDS, $rp_path, COOKIE_DOMAIN, is_ssl(), true );
+		// phpcs:disable WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- target is always a hardcoded site_url() string, never raw user input.
 		wp_redirect( site_url( 'wp-login.php?resetpass=complete' ) );
+		// phpcs:enable WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
 		exit;
 	} else {
 		tml_set_errors( $errors );
 	}
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing
 }
 
 /**
@@ -750,6 +836,8 @@ function tml_password_reset_handler() {
  * @since 7.0
  */
 function tml_confirmaction_handler() {
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended -- mirrors wp-login.php's own confirmaction handling, which is secured by the confirm_key/wp_validate_user_request_key() token rather than a nonce.
+	// phpcs:disable WordPress.WP.I18n.MissingArgDomain, WordPress.Security.EscapeOutput.OutputNotEscaped -- these messages intentionally reuse WP core's translated wp-login.php strings verbatim (static, no dynamic content), not TML-specific strings.
 	if ( ! isset( $_GET['request_id'] ) ) {
 		wp_die( __( 'Missing request ID.' ) );
 	}
@@ -757,14 +845,18 @@ function tml_confirmaction_handler() {
 	if ( ! isset( $_GET['confirm_key'] ) ) {
 		wp_die( __( 'Missing confirm key.' ) );
 	}
+	// phpcs:enable WordPress.WP.I18n.MissingArgDomain, WordPress.Security.EscapeOutput.OutputNotEscaped
 
 	$request_id = (int) $_GET['request_id'];
 	$key        = sanitize_text_field( wp_unslash( $_GET['confirm_key'] ) );
 	$result     = wp_validate_user_request_key( $request_id, $key );
 
 	if ( is_wp_error( $result ) ) {
+		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_die() natively supports WP_Error objects (extracts get_error_message() internally via _wp_die_process_input()); this is the standard wp_die( WP_Error ) pattern, not raw unescaped output.
 		wp_die( $result );
+		// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 	/** This action is documented in wp-login.php */
 	do_action( 'user_request_action_confirmed', $request_id );

--- a/src/includes/class-theme-my-login-action.php
+++ b/src/includes/class-theme-my-login-action.php
@@ -115,17 +115,20 @@ class Theme_My_Login_Action {
 
 		$this->set_name( $name );
 
-		$args = wp_parse_args( $args, array(
-			'title'                 => '',
-			'slug'                  => '',
-			'callback'              => '',
-			'ajax_callback'         => '',
-			'network'               => false,
-			'show_on_forms'         => true,
-			'show_in_widget'        => true,
-			'show_in_nav_menus'     => true,
-			'show_in_slug_settings' => true,
-		) );
+		$args = wp_parse_args(
+			$args,
+			array(
+				'title'                 => '',
+				'slug'                  => '',
+				'callback'              => '',
+				'ajax_callback'         => '',
+				'network'               => false,
+				'show_on_forms'         => true,
+				'show_in_widget'        => true,
+				'show_in_nav_menus'     => true,
+				'show_in_slug_settings' => true,
+			)
+		);
 
 		if ( ! isset( $args['show_nav_menu_item'] ) ) {
 			$args['show_nav_menu_item'] = $args['show_in_nav_menus'];
@@ -224,7 +227,8 @@ class Theme_My_Login_Action {
 	 * @since 7.0.3
 	 */
 	public function add_callback_hook() {
-		if ( $callback = $this->get_callback() ) {
+		$callback = $this->get_callback();
+		if ( $callback ) {
 			add_action( 'tml_action_' . $this->get_name(), $callback, 15 );
 		}
 	}
@@ -235,7 +239,8 @@ class Theme_My_Login_Action {
 	 * @since 7.0.3
 	 */
 	public function remove_callback_hook() {
-		if ( $callback = $this->get_callback() ) {
+		$callback = $this->get_callback();
+		if ( $callback ) {
 			remove_action( 'tml_action_' . $this->get_name(), $callback, 15 );
 		}
 	}
@@ -268,7 +273,8 @@ class Theme_My_Login_Action {
 	 * @since 7.1
 	 */
 	public function add_ajax_callback_hook() {
-		if ( $ajax_callback = $this->get_ajax_callback() ) {
+		$ajax_callback = $this->get_ajax_callback();
+		if ( $ajax_callback ) {
 			add_action( 'tml_action_ajax_' . $this->get_name(), $ajax_callback, 15 );
 		}
 	}
@@ -279,7 +285,8 @@ class Theme_My_Login_Action {
 	 * @since 7.1
 	 */
 	public function remove_ajax_callback_hook() {
-		if ( $ajax_callback = $this->get_ajax_callback() ) {
+		$ajax_callback = $this->get_ajax_callback();
+		if ( $ajax_callback ) {
 			remove_action( 'tml_action_ajax_' . $this->get_name(), $ajax_callback, 15 );
 		}
 	}
@@ -336,11 +343,13 @@ class Theme_My_Login_Action {
 		$function = $network ? 'network_home_url' : 'home_url';
 
 		if ( tml_use_permalinks() ) {
-			$path = user_trailingslashit( str_replace(
-				'%pagename%',
-				$this->get_slug(),
-				$wp_rewrite->get_page_permastruct()
-			) );
+			$path = user_trailingslashit(
+				str_replace(
+					'%pagename%',
+					$this->get_slug(),
+					$wp_rewrite->get_page_permastruct()
+				)
+			);
 			$url  = $function( $path, $scheme );
 		} else {
 			$url = $function( '?action=' . $this->get_name(), $scheme );

--- a/src/includes/class-theme-my-login-form-field.php
+++ b/src/includes/class-theme-my-login-form-field.php
@@ -133,16 +133,19 @@ class Theme_My_Login_Form_Field {
 		$this->set_form( $form );
 		$this->set_name( $name );
 
-		$args = wp_parse_args( $args, array(
-			'type'        => 'text',
-			'value'       => '',
-			'label'       => '',
-			'description' => '',
-			'error'       => '',
-			'content'     => '',
-			'options'     => array(),
-			'attributes'  => array(),
-		) );
+		$args = wp_parse_args(
+			$args,
+			array(
+				'type'        => 'text',
+				'value'       => '',
+				'label'       => '',
+				'description' => '',
+				'error'       => '',
+				'content'     => '',
+				'options'     => array(),
+				'attributes'  => array(),
+			)
+		);
 
 		$this->set_type( $args['type'] );
 		$this->set_value( $args['value'] );
@@ -158,10 +161,10 @@ class Theme_My_Login_Form_Field {
 
 		if ( ! empty( $args['class'] ) ) {
 			$this->add_class( $args['class'] );
-		} elseif ( 'hidden' != $this->get_type() ) {
-			if ( in_array( $args['type'], array( 'button', 'submit', 'reset' ) ) ) {
+		} elseif ( 'hidden' !== $this->get_type() ) {
+			if ( in_array( $args['type'], array( 'button', 'submit', 'reset' ), true ) ) {
 				$class = 'tml-button';
-			} elseif ( in_array( $args['type'], array( 'checkbox', 'radio', 'radio-group' ) ) ) {
+			} elseif ( in_array( $args['type'], array( 'checkbox', 'radio', 'radio-group' ), true ) ) {
 				$class = 'tml-checkbox';
 			} else {
 				$class = 'tml-field';
@@ -169,7 +172,7 @@ class Theme_My_Login_Form_Field {
 			$this->add_class( $class );
 		}
 
-		if ( 'checkbox' == $args['type'] && ! empty( $args['checked'] ) ) {
+		if ( 'checkbox' === $args['type'] && ! empty( $args['checked'] ) ) {
 			$this->add_attribute( 'checked', 'checked' );
 		}
 
@@ -475,7 +478,7 @@ class Theme_My_Login_Form_Field {
 	 *
 	 * @param array|string $class The class or an array of classes.
 	 */
-	public function add_class( $class ) {
+	public function add_class( $class ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.classFound -- public API parameter name, renaming risks breaking PHP 8 named-argument callers.
 		if ( ! is_array( $class ) ) {
 			$class = explode( ' ', $class );
 		}
@@ -489,7 +492,7 @@ class Theme_My_Login_Form_Field {
 	 *
 	 * @param string $class The class.
 	 */
-	public function remove_class( $class ) {
+	public function remove_class( $class ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.classFound -- public API parameter name, renaming risks breaking PHP 8 named-argument callers.
 		$classes = array_flip( $this->classes );
 		if ( isset( $classes[ $class ] ) ) {
 			unset( $classes[ $class ] );
@@ -505,8 +508,8 @@ class Theme_My_Login_Form_Field {
 	 * @param string $class The class.
 	 * @return bool True if the field has the given class, false if not.
 	 */
-	public function has_class( $class ) {
-		return in_array( $class, $this->classes );
+	public function has_class( $class ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.classFound -- public API parameter name, renaming risks breaking PHP 8 named-argument callers.
+		return in_array( $class, $this->classes, true );
 	}
 
 	/**
@@ -557,18 +560,21 @@ class Theme_My_Login_Form_Field {
 	 * }
 	 */
 	public function render( $args = array() ) {
-		$is_hidden = ( 'hidden' == $this->get_type() );
+		$is_hidden = ( 'hidden' === $this->get_type() );
 
-		if ( 'action' == $this->get_type() ) {
+		if ( 'action' === $this->get_type() ) {
 			return tml_buffer_action_hook( $this->get_name(), $this->render_args );
 		}
 
-		$defaults = wp_parse_args( $this->render_args, array(
-			'before'         => $is_hidden ? '' : '<div class="tml-field-wrap tml-%s-wrap">',
-			'after'          => $is_hidden ? '' : '</div>',
-			'control_before' => '',
-			'control_after'  => '',
-		) );
+		$defaults = wp_parse_args(
+			$this->render_args,
+			array(
+				'before'         => $is_hidden ? '' : '<div class="tml-field-wrap tml-%s-wrap">',
+				'after'          => $is_hidden ? '' : '</div>',
+				'control_before' => '',
+				'control_after'  => '',
+			)
+		);
 
 		/**
 		 * Fires before a form field is rendered.
@@ -605,7 +611,8 @@ class Theme_My_Login_Form_Field {
 		foreach ( $this->get_attributes() as $key => $value ) {
 			$attributes .= ' ' . $key . '="' . esc_attr( $value ) . '"';
 		}
-		if ( $classes = $this->get_classes() ) {
+		$classes = $this->get_classes();
+		if ( $classes ) {
 			$attributes .= ' class="' . implode( ' ', $classes ) . '"';
 		}
 
@@ -631,19 +638,19 @@ class Theme_My_Login_Form_Field {
 		}
 
 		switch ( $this->get_type() ) {
-			case 'custom' :
+			case 'custom':
 				$output .= $label;
 				$output .= $this->get_content();
 				break;
 
-			case 'checkbox' :
+			case 'checkbox':
 				$output .= $args['control_before'];
 				$output .= '<input name="' . $this->get_name() . '" type="checkbox" value="' . esc_attr( $this->get_value() ) . '"' . $attributes . ">\n";
 				$output .= $args['control_after'];
 				$output .= $label;
 				break;
 
-			case 'radio-group' :
+			case 'radio-group':
 				$output .= $label;
 				$output .= $error;
 				$output .= $args['control_before'];
@@ -653,7 +660,7 @@ class Theme_My_Login_Form_Field {
 					$id = $this->get_name() . '_' . $value;
 
 					$option = '<input name="' . $this->get_name() . '" id="' . $id . '" type="radio" value="' . esc_attr( $value ) . '"' . $attributes;
-					if ( $this->get_value() == $value ) {
+					if ( (string) $this->get_value() === (string) $value ) {
 						$option .= ' checked="checked"';
 					}
 					$option .= '>' . "\n";
@@ -666,14 +673,14 @@ class Theme_My_Login_Form_Field {
 				$output .= $args['control_after'];
 				break;
 
-			case 'dropdown' :
+			case 'dropdown':
 				$output .= $label;
 				$output .= $error;
 				$output .= $args['control_before'];
 				$output .= '<select name="' . $this->get_name() . '"' . $attributes . ">\n";
 				foreach ( $this->get_options() as $value => $option ) {
 					$output .= '<option value="' . esc_attr( $value ) . '"';
-					if ( $this->get_value() == $value ) {
+					if ( (string) $this->get_value() === (string) $value ) {
 						$output .= ' selected="selected"';
 					}
 					$output .= '>' . esc_html( $option ) . "</option>\n";
@@ -682,21 +689,21 @@ class Theme_My_Login_Form_Field {
 				$output .= $args['control_after'];
 				break;
 
-			case 'textarea' :
+			case 'textarea':
 				$output .= $label;
 				$output .= $args['control_before'];
 				$output .= '<textarea name="' . $this->get_name() . '"' . $attributes . '>' . esc_textarea( $this->get_value() ) . "</textarea>\n";
 				$output .= $args['control_after'];
 				break;
 
-			case 'button' :
-			case 'submit' :
+			case 'button':
+			case 'submit':
 				$output .= $args['control_before'];
 				$output .= '<button name="' . $this->get_name() . '" type="' . $this->get_type() . '"' . $attributes . '>' . $this->get_value() . "</button>\n";
 				$output .= $args['control_after'];
 				break;
 
-			default :
+			default:
 				$output .= $label;
 				$output .= $error;
 				$output .= $args['control_before'];

--- a/src/includes/class-theme-my-login-form.php
+++ b/src/includes/class-theme-my-login-form.php
@@ -90,24 +90,30 @@ class Theme_My_Login_Form {
 
 		$this->set_name( $name );
 
-		$args = wp_parse_args( $args, array(
-			'action'     => '',
-			'method'     => 'post',
-			'attributes' => array(),
-		) );
+		$args = wp_parse_args(
+			$args,
+			array(
+				'action'     => '',
+				'method'     => 'post',
+				'attributes' => array(),
+			)
+		);
 
 		$this->set_action( $args['action'] );
 		$this->set_method( $args['method'] );
 
-		$this->errors = new WP_Error;
+		$this->errors = new WP_Error();
 
 		// Add the default links
 		foreach ( tml_get_actions() as $action ) {
-			if ( $action->show_on_forms && $action->get_name() != $this->get_name() ) {
-				$this->add_link( $action->get_name(), array(
-					'text' => true === $action->show_on_forms ? $action->get_title() : $action->show_on_forms,
-					'url'  => $action->get_url(),
-				) );
+			if ( $action->show_on_forms && $action->get_name() !== $this->get_name() ) {
+				$this->add_link(
+					$action->get_name(),
+					array(
+						'text' => true === $action->show_on_forms ? $action->get_title() : $action->show_on_forms,
+						'url'  => $action->get_url(),
+					)
+				);
 			}
 		}
 
@@ -200,7 +206,7 @@ class Theme_My_Login_Form {
 	 */
 	public function set_method( $method ) {
 		$method = strtolower( $method );
-		if ( ! in_array( $method, array( 'get', 'post' ) ) ) {
+		if ( ! in_array( $method, array( 'get', 'post' ), true ) ) {
 			$method = 'post';
 		}
 		$this->method = $method;
@@ -313,7 +319,7 @@ class Theme_My_Login_Form {
 		$sorted_fields = array();
 
 		// Prioritize the fields
-		foreach( $this->fields as $field ) {
+		foreach ( $this->fields as $field ) {
 			$priority = $field->get_priority();
 			if ( ! isset( $priorities[ $priority ] ) ) {
 				$priorities[ $priority ] = array();
@@ -401,7 +407,7 @@ class Theme_My_Login_Form {
 			$severity = $this->errors->get_error_data( $code );
 
 			foreach ( $this->errors->get_error_messages( $code ) as $error ) {
-				if ( 'message' == $severity ) {
+				if ( 'message' === $severity ) {
 					$messages[] = $error;
 				} else {
 					$errors[] = $error;
@@ -412,13 +418,15 @@ class Theme_My_Login_Form {
 		$output = '';
 
 		if ( ! empty( $errors ) ) {
-			$output .= sprintf( '<ul class="tml-errors"><li class="tml-error">%s</li></ul>',
+			$output .= sprintf(
+				'<ul class="tml-errors"><li class="tml-error">%s</li></ul>',
 				apply_filters( 'login_errors', implode( "</li>\n<li class=\"tml-error\">", $errors ) )
 			);
 		}
 
 		if ( ! empty( $messages ) ) {
-			$output .= sprintf( '<ul class="tml-messages"><li class="tml-message">%s</li></ul>',
+			$output .= sprintf(
+				'<ul class="tml-messages"><li class="tml-message">%s</li></ul>',
 				apply_filters( 'login_messages', implode( "</li>\n<li class=\"tml-message\">", $messages ) )
 			);
 		}
@@ -440,10 +448,13 @@ class Theme_My_Login_Form {
 	 * }
 	 */
 	public function add_link( $link, $args = array() ) {
-		$args = wp_parse_args( $args, array(
-			'text' => '',
-			'url'  => '',
-		) );
+		$args = wp_parse_args(
+			$args,
+			array(
+				'text' => '',
+				'url'  => '',
+			)
+		);
 
 		$link = sanitize_key( $link );
 
@@ -504,14 +515,16 @@ class Theme_My_Login_Form {
 	 */
 	public function render_links() {
 
-		if ( ! $links = $this->get_links() ) {
+		$links = $this->get_links();
+		if ( ! $links ) {
 			return;
 		}
 
 		$output = '<ul class="tml-links">';
 
 		foreach ( $links as $name => $link ) {
-			$output .= sprintf( '<li class="tml-%s-link"><a href="%s">%s</a></li>',
+			$output .= sprintf(
+				'<li class="tml-%s-link"><a href="%s">%s</a></li>',
 				esc_attr( $name ),
 				esc_url( $link['url'] ),
 				esc_html( $link['text'] )
@@ -564,15 +577,18 @@ class Theme_My_Login_Form {
 	 * @return string The form markup.
 	 */
 	public function render( $args = array() ) {
-		$defaults = wp_parse_args( $this->render_args, array(
-			'container'       => 'div',
-			'container_class' => 'tml tml-%s',
-			'container_id'    => '',
-			'before'          => '',
-			'after'           => '',
-			'show_links'      => true,
-			'show_form'       => true,
-		) );
+		$defaults = wp_parse_args(
+			$this->render_args,
+			array(
+				'container'       => 'div',
+				'container_class' => 'tml tml-%s',
+				'container_id'    => '',
+				'before'          => '',
+				'after'           => '',
+				'show_links'      => true,
+				'show_form'       => true,
+			)
+		);
 
 		/**
 		 * Fires before rendering a form.

--- a/src/includes/class-theme-my-login-widget.php
+++ b/src/includes/class-theme-my-login-widget.php
@@ -19,11 +19,15 @@ class Theme_My_Login_Widget extends WP_Widget {
 	 *
 	 * @since 6.0
 	 */
-	public function  __construct() {
-		parent::__construct( 'theme-my-login', __( 'Theme My Login', 'theme-my-login' ), array(
-			'classname'   => 'widget_theme_my_login',
-			'description' => __( 'A login form for your site.', 'theme-my-login' ),
-		) );
+	public function __construct() {
+		parent::__construct(
+			'theme-my-login',
+			__( 'Theme My Login', 'theme-my-login' ),
+			array(
+				'classname'   => 'widget_theme_my_login',
+				'description' => __( 'A login form for your site.', 'theme-my-login' ),
+			)
+		);
 	}
 
 	/**
@@ -37,7 +41,7 @@ class Theme_My_Login_Widget extends WP_Widget {
 	public function widget( $args, $instance ) {
 		$instance = wp_parse_args( $instance, $this->defaults() );
 
-		$show_widget = ( is_user_logged_in() && 'login' != $instance['action'] ) || ! tml_is_action();
+		$show_widget = ( is_user_logged_in() && 'login' !== $instance['action'] ) || ! tml_is_action();
 
 		/**
 		 * Filters whether to show the widget or not.
@@ -60,9 +64,11 @@ class Theme_My_Login_Widget extends WP_Widget {
 		}
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- before_widget/before_title/after_title come from the theme's register_sidebar() args, not request data; matches how every WP core bundled widget outputs them.
 		echo $args['before_widget'];
 
 		if ( $title ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- matches WP core's own widget convention of not escaping widget_title-filtered output (see e.g. WP_Widget_Pages::widget()); before_title/after_title are theme-provided wrapper markup.
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 
@@ -83,24 +89,31 @@ class Theme_My_Login_Widget extends WP_Widget {
 			 *
 			 * @param array $user_links The links shown in the widget when logged in.
 			 */
-			$user_links = apply_filters( 'tml_widget_user_links', array_filter( array(
-				'site_admin' => current_user_can( 'edit_posts' ) ? array(
-					'title'  => __( 'Site Admin' ),
-					'url'    => admin_url(),
-				) : false,
-				'dashboard'  => array(
-					'title'  => __( 'Dashboard' ),
-					'url'    => tml_get_action_url( 'dashboard' ),
-				),
-				'profile'    => array(
-					'title'  => __( 'Edit Profile' ),
-					'url'    => admin_url( 'profile.php' ),
-				),
-				'logout'     => array(
-					'title'  => __( 'Log Out' ),
-					'url'    => wp_logout_url(),
-				),
-			) ) );
+			// phpcs:disable WordPress.WP.I18n.MissingArgDomain -- these labels intentionally reuse WP core's translated strings ("Site Admin"/"Dashboard"/"Edit Profile"/"Log Out" all exist verbatim in wp-admin/wp-includes), not TML-specific strings.
+			$user_links = apply_filters(
+				'tml_widget_user_links',
+				array_filter(
+					array(
+						'site_admin' => current_user_can( 'edit_posts' ) ? array(
+							'title' => __( 'Site Admin' ),
+							'url'   => admin_url(),
+						) : false,
+						'dashboard'  => array(
+							'title' => __( 'Dashboard' ),
+							'url'   => tml_get_action_url( 'dashboard' ),
+						),
+						'profile'    => array(
+							'title' => __( 'Edit Profile' ),
+							'url'   => admin_url( 'profile.php' ),
+						),
+						'logout'     => array(
+							'title' => __( 'Log Out' ),
+							'url'   => wp_logout_url(),
+						),
+					)
+				)
+			);
+			// phpcs:enable WordPress.WP.I18n.MissingArgDomain
 			?>
 
 			<div class="tml tml-user-panel">
@@ -135,16 +148,21 @@ class Theme_My_Login_Widget extends WP_Widget {
 
 			</div>
 
-		<?php else :
+			<?php
+		else :
 
-			echo tml_shortcode( array(
-				'action'      => $instance['action'],
-				'show_links'  => $instance['show_links'],
-				'redirect_to' => $_SERVER['REQUEST_URI'],
-			) );
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- tml_shortcode() builds its own safely-escaped markup internally (see includes/shortcodes.php).
+			echo tml_shortcode(
+				array(
+					'action'      => $instance['action'],
+					'show_links'  => $instance['show_links'],
+					'redirect_to' => $_SERVER['REQUEST_URI'],
+				)
+			);
 
 		endif;
 
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- after_widget comes from the theme's register_sidebar() args, not request data; matches how every WP core bundled widget outputs it.
 		echo $args['after_widget'];
 	}
 
@@ -157,14 +175,17 @@ class Theme_My_Login_Widget extends WP_Widget {
 	public function form( $instance ) {
 		$instance = wp_parse_args( $instance, $this->defaults() );
 
-		$actions = wp_list_filter( tml_get_actions(), array(
-			'show_in_widget' => true,
-		) );
+		$actions = wp_list_filter(
+			tml_get_actions(),
+			array(
+				'show_in_widget' => true,
+			)
+		);
 		?>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'action' ); ?>"><?php _e( 'Action:' ); ?>
-				<select class="widefat" id="<?php echo $this->get_field_id( 'action' ); ?>" name="<?php echo $this->get_field_name( 'action' ); ?>">
+			<label for="<?php echo esc_attr( $this->get_field_id( 'action' ) ); ?>"><?php esc_html_e( 'Action:', 'theme-my-login' ); ?>
+				<select class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'action' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'action' ) ); ?>">
 					<?php foreach ( $actions as $action ) : ?>
 						<option value="<?php echo esc_attr( $action->get_name() ); ?>"<?php selected( $action->get_name(), $instance['action'] ); ?>><?php echo esc_html( $action->get_title() ); ?></option>
 					<?php endforeach; ?>
@@ -173,8 +194,8 @@ class Theme_My_Login_Widget extends WP_Widget {
 		</p>
 
 		<p>
-			<input class="checkbox" id="<?php echo $this->get_field_id( 'show_links' ); ?>" name="<?php echo $this->get_field_name( 'show_links' ); ?>" type="checkbox" value="1"<?php checked( ! empty( $instance['show_links'] ) ); ?> />
-			<label for="<?php echo $this->get_field_id( 'show_links' ); ?>"><?php _e( 'Show action links?', 'theme-my-login' ); ?></label>
+			<input class="checkbox" id="<?php echo esc_attr( $this->get_field_id( 'show_links' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'show_links' ) ); ?>" type="checkbox" value="1"<?php checked( ! empty( $instance['show_links'] ) ); ?> />
+			<label for="<?php echo esc_attr( $this->get_field_id( 'show_links' ) ); ?>"><?php esc_html_e( 'Show action links?', 'theme-my-login' ); ?></label>
 		</p>
 
 		<?php
@@ -209,7 +230,7 @@ class Theme_My_Login_Widget extends WP_Widget {
 	 */
 	public function defaults() {
 		return array(
-			'action' => 'login',
+			'action'     => 'login',
 			'show_links' => false,
 		);
 	}

--- a/src/includes/class-theme-my-login-widget.php
+++ b/src/includes/class-theme-my-login-widget.php
@@ -184,7 +184,7 @@ class Theme_My_Login_Widget extends WP_Widget {
 		?>
 
 		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'action' ) ); ?>"><?php esc_html_e( 'Action:', 'theme-my-login' ); ?>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'action' ) ); ?>"><?php esc_html_e( 'Action' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reuses WP core's translated "Action" string verbatim, not a TML-specific string. ?>
 				<select class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'action' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'action' ) ); ?>">
 					<?php foreach ( $actions as $action ) : ?>
 						<option value="<?php echo esc_attr( $action->get_name() ); ?>"<?php selected( $action->get_name(), $instance['action'] ); ?>><?php echo esc_html( $action->get_title() ); ?></option>

--- a/src/includes/class-theme-my-login.php
+++ b/src/includes/class-theme-my-login.php
@@ -99,18 +99,14 @@ final class Theme_My_Login {
 	 * @param string|Theme_My_Login_Action $action The action name or object.
 	 */
 	public function unregister_action( $action ) {
-		if ( $action instanceof Theme_My_Login_Action ) {
+		if ( ! $action instanceof Theme_My_Login_Action ) {
+			$action = $this->get_action( $action );
+		}
 
+		if ( $action instanceof Theme_My_Login_Action ) {
 			$action->remove_callback_hook();
 
 			unset( $this->actions[ $action->get_name() ] );
-		} else {
-			if ( $action = $this->get_action( $action ) ) {
-
-				$action->remove_callback_hook();
-
-				unset( $this->actions[ $action->get_name() ] );
-			}
 		}
 	}
 
@@ -309,7 +305,7 @@ final class Theme_My_Login {
 	 * @param mixed  $default The value to return if the property is not set.
 	 * @return mixed The property value or $default if not set.
 	 */
-	public function get_data( $name, $default = false ) {
+	public function get_data( $name, $default = false ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.defaultFound -- public API parameter name, renaming risks breaking PHP 8 named-argument callers.
 		if ( array_key_exists( $name, $this->data ) ) {
 			return $this->data[ $name ];
 		}
@@ -326,7 +322,7 @@ final class Theme_My_Login {
 	 */
 	public function set_data( $name, $value = '' ) {
 		if ( is_array( $name ) ) {
-			foreach( $name as $k => $v ) {
+			foreach ( $name as $k => $v ) {
 				$this->data[ $k ] = $v;
 			}
 		} else {
@@ -366,13 +362,11 @@ final class Theme_My_Login {
 	 */
 	public static function __callStatic( $name, $args ) {
 		switch ( $name ) {
-			case 'get_object' :
+			case 'get_object':
 				return self::get_instance();
-				break;
 
-			case 'is_tml_page' :
+			case 'is_tml_page':
 				return tml_is_action( isset( $args[0] ) ? $args[0] : '' );
-				break;
 		}
 	}
 }

--- a/src/includes/commands.php
+++ b/src/includes/commands.php
@@ -44,52 +44,56 @@
  *     $ wp menu item add-tml-action sidebar-menu login
  *     Success: Menu item added.
  */
-WP_CLI::add_command( 'menu item add-tml-action', function( $args, $assoc_args ) {
+WP_CLI::add_command(
+	'menu item add-tml-action',
+	function ( $args, $assoc_args ) {
 
-	list( $menu, $action ) = $args;
+		list( $menu, $action ) = $args;
 
-	$menu = wp_get_nav_menu_object( $menu );
-	if ( ! $menu || is_wp_error( $menu ) ) {
-		WP_CLI::error( 'Invalid menu.' );
-	}
-	if ( ! $action = tml_get_action( $action ) ) {
-		WP_CLI::error( 'Invalid action.' );
-	}
-
-	$default_args = [
-		'position'    => 0,
-		'title'       => $action->get_title(),
-		'description' => '',
-		'parent-id'   => 0,
-		'attr-title'  => '',
-		'target'      => '',
-		'classes'     => '',
-		'xfn'         => '',
-		'status'      => 'publish',
-	];
-
-	$menu_item_args = [];
-	foreach ( $default_args as $key => $default_value ) {
-		$menu_item_args[ 'menu-item-' . $key ] = \WP_CLI\Utils\get_flag_value( $assoc_args, $key, $default_value );
-	}
-	$menu_item_args['menu-item-object-id'] = -1;
-	$menu_item_args['menu-item-object']    = $action->get_name();
-	$menu_item_args['menu-item-type']      = 'tml_action';
-	$menu_item_args['menu-item-url']       = $action->get_url();
-
-	$ret = wp_update_nav_menu_item( $menu->term_id, 0, $menu_item_args );
-	if ( is_wp_error( $ret ) ) {
-		WP_CLI::error( $ret->get_error_message() );
-	} elseif ( ! $ret ) {
-		WP_CLI::error( "Couldn't add menu item." );
-	} else {
-		if ( ! is_object_in_term( $ret, 'nav_menu', (int) $menu->term_id ) ) {
-			wp_set_object_terms( $ret, array( (int) $menu->term_id ), 'nav_menu' );
+		$menu = wp_get_nav_menu_object( $menu );
+		if ( ! $menu || is_wp_error( $menu ) ) {
+			WP_CLI::error( 'Invalid menu.' );
 		}
-		if ( ! empty( $assoc_args['porcelain'] ) ) {
-			WP_CLI::line( $ret );
+		$action = tml_get_action( $action );
+		if ( ! $action ) {
+			WP_CLI::error( 'Invalid action.' );
+		}
+
+		$default_args = array(
+			'position'    => 0,
+			'title'       => $action->get_title(),
+			'description' => '',
+			'parent-id'   => 0,
+			'attr-title'  => '',
+			'target'      => '',
+			'classes'     => '',
+			'xfn'         => '',
+			'status'      => 'publish',
+		);
+
+		$menu_item_args = array();
+		foreach ( $default_args as $key => $default_value ) {
+			$menu_item_args[ 'menu-item-' . $key ] = \WP_CLI\Utils\get_flag_value( $assoc_args, $key, $default_value );
+		}
+		$menu_item_args['menu-item-object-id'] = -1;
+		$menu_item_args['menu-item-object']    = $action->get_name();
+		$menu_item_args['menu-item-type']      = 'tml_action';
+		$menu_item_args['menu-item-url']       = $action->get_url();
+
+		$ret = wp_update_nav_menu_item( $menu->term_id, 0, $menu_item_args );
+		if ( is_wp_error( $ret ) ) {
+			WP_CLI::error( $ret->get_error_message() );
+		} elseif ( ! $ret ) {
+			WP_CLI::error( "Couldn't add menu item." );
 		} else {
-			WP_CLI::success( 'Menu item added.' );
+			if ( ! is_object_in_term( $ret, 'nav_menu', (int) $menu->term_id ) ) {
+				wp_set_object_terms( $ret, array( (int) $menu->term_id ), 'nav_menu' );
+			}
+			if ( ! empty( $assoc_args['porcelain'] ) ) {
+				WP_CLI::line( $ret );
+			} else {
+				WP_CLI::success( 'Menu item added.' );
+			}
 		}
 	}
-});
+);

--- a/src/includes/compat.php
+++ b/src/includes/compat.php
@@ -20,6 +20,8 @@
  * @return True on success, WP_Error on error.
  */
 function tml_retrieve_password() {
+	// phpcs:disable WordPress.Security.NonceVerification.Missing -- mirrors wp-includes/user.php's retrieve_password(), a public unauthenticated form with no nonce.
+	// phpcs:disable WordPress.WP.I18n.MissingArgDomain -- these messages intentionally reuse WP core's translated strings verbatim (see wp-includes/user.php's retrieve_password()), not TML-specific strings.
 	$errors    = new WP_Error();
 	$user_data = false;
 
@@ -34,6 +36,7 @@ function tml_retrieve_password() {
 		$login     = trim( wp_unslash( $_POST['user_login'] ) );
 		$user_data = get_user_by( 'login', $login );
 	}
+	// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 	/** Tis filter is documented in wp-login.php */
 	$user_data = apply_filters( 'lostpassword_user_data', $user_data, $errors );
@@ -52,6 +55,7 @@ function tml_retrieve_password() {
 		$errors->add( 'invalidcombo', __( '<strong>Error:</strong> There is no account with that username or email address.' ) );
 		return $errors;
 	}
+	// phpcs:enable WordPress.WP.I18n.MissingArgDomain
 
 	$key = get_password_reset_key( $user_data );
 	if ( is_wp_error( $key ) ) {
@@ -90,10 +94,9 @@ function tml_retrieve_password_notification( $user, $key ) {
 		$site_name = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
 	}
 
-	$message = __( 'Someone has requested a password reset for the following account:' ) . "\r\n\r\n";
-	/* translators: %s: site name */
+	// phpcs:disable WordPress.WP.I18n.MissingArgDomain, WordPress.WP.I18n.MissingTranslatorsComment -- these messages intentionally reuse WP core's translated strings verbatim (see wp-includes/user.php's retrieve_password_notification email), not TML-specific strings; no translators comments since they never enter TML's own .pot.
+	$message  = __( 'Someone has requested a password reset for the following account:' ) . "\r\n\r\n";
 	$message .= sprintf( __( 'Site Name: %s' ), $site_name ) . "\r\n\r\n";
-	/* translators: %s: user login */
 	$message .= sprintf( __( 'Username: %s' ), $user->user_login ) . "\r\n\r\n";
 	$message .= __( 'If this was a mistake, just ignore this email and nothing will happen.' ) . "\r\n\r\n";
 	$message .= __( 'To reset your password, visit the following address:' ) . "\r\n\r\n";
@@ -102,14 +105,13 @@ function tml_retrieve_password_notification( $user, $key ) {
 	$requester_ip = $_SERVER['REMOTE_ADDR'];
 	if ( $requester_ip ) {
 		$message .= sprintf(
-			/* translators: %s: IP address of password reset requester. */
 			__( 'This password reset request originated from the IP address %s.' ),
 			$requester_ip
 		) . "\r\n";
 	}
 
-	/* translators: Password reset email subject. %s: Site name */
 	$title = sprintf( __( '[%s] Password Reset' ), $site_name );
+	// phpcs:enable WordPress.WP.I18n.MissingArgDomain, WordPress.WP.I18n.MissingTranslatorsComment
 
 	/**
 	 * Filters the subject of the password reset email.
@@ -169,9 +171,13 @@ function tml_retrieve_password_notification( $user, $key ) {
 		$retrieve_password_email['message'],
 		$retrieve_password_email['headers']
 	) ) {
-		wp_die( sprintf(
-			__( '<strong>Error:</strong> The email could not be sent. Your site may not be correctly configured to send emails. <a href="%s">Get support for resetting your password</a>.' ),
-			esc_url( __( 'https://wordpress.org/documentation/article/reset-your-password/' ) )
-		) );
+		// phpcs:disable WordPress.WP.I18n.MissingArgDomain, WordPress.WP.I18n.MissingTranslatorsComment, WordPress.Security.EscapeOutput.OutputNotEscaped -- reusing WP core's translated strings verbatim (see wp-includes/user.php); no translators comment since this never enters TML's own .pot; the dynamic URL is already esc_url()'d.
+		wp_die(
+			sprintf(
+				__( '<strong>Error:</strong> The email could not be sent. Your site may not be correctly configured to send emails. <a href="%s">Get support for resetting your password</a>.' ),
+				esc_url( __( 'https://wordpress.org/documentation/article/reset-your-password/' ) )
+			)
+			// phpcs:enable WordPress.WP.I18n.MissingArgDomain, WordPress.WP.I18n.MissingTranslatorsComment, WordPress.Security.EscapeOutput.OutputNotEscaped
+		);
 	}
 }

--- a/src/includes/extensions.php
+++ b/src/includes/extensions.php
@@ -173,8 +173,6 @@ function tml_add_extension_data_to_plugins_transient( $transient = '' ) {
 			// This is a valid update
 			if ( ! empty( $update->new_version ) && version_compare( $extension->get_version(), $update->new_version, '<' ) ) {
 				$transient->response[ $basename ] = $update;
-
-				// This is just fetching the plugin information
 			} else {
 				$transient->no_update[ $basename ] = $update;
 			}

--- a/src/includes/extensions.php
+++ b/src/includes/extensions.php
@@ -99,12 +99,10 @@ function tml_extension_exists( $extension ) {
  */
 function tml_add_extension_data_to_plugins_api( $result = false, $action = '', $args = array() ) {
 
-	// Bail if not a "plugin_information" call
 	if ( 'plugin_information' !== $action ) {
 		return $result;
 	}
 
-	// Bail if the extension doesn't exist
 	$extension = tml_get_extension( $args->slug );
 	if ( ! $extension ) {
 		return $result;

--- a/src/includes/extensions.php
+++ b/src/includes/extensions.php
@@ -18,7 +18,7 @@
  * }
  * @return Theme_My_Login_Extension The extension object.
  */
-function tml_register_extension( $extension, $args = array() ) {
+function tml_register_extension( $extension, $args = array() ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- kept for API/documented-signature consistency with tml_register_action()/tml_register_form().
 
 	if ( ! $extension instanceof Theme_My_Login_Extension ) {
 		return false;
@@ -100,20 +100,25 @@ function tml_extension_exists( $extension ) {
 function tml_add_extension_data_to_plugins_api( $result = false, $action = '', $args = array() ) {
 
 	// Bail if not a "plugin_information" call
-	if ( 'plugin_information' != $action ) {
+	if ( 'plugin_information' !== $action ) {
 		return $result;
 	}
 
 	// Bail if the extension doesn't exist
-	if ( ! $extension = tml_get_extension( $args->slug ) ) {
+	$extension = tml_get_extension( $args->slug );
+	if ( ! $extension ) {
 		return $result;
 	}
 
-	if ( $result = tml_extension_api_call( $extension->get_store_url(), array(
-		'license' => $extension->get_license_key(),
-		'item_id' => $extension->get_item_id(),
-		'slug'    => $extension->get_name(),
-	) ) ) {
+	$result = tml_extension_api_call(
+		$extension->get_store_url(),
+		array(
+			'license' => $extension->get_license_key(),
+			'item_id' => $extension->get_item_id(),
+			'slug'    => $extension->get_name(),
+		)
+	);
+	if ( $result ) {
 		if ( empty( $result->version ) && ! empty( $result->new_version ) ) {
 			$result->version = $result->new_version;
 		}
@@ -136,11 +141,14 @@ function tml_add_extension_data_to_plugins_transient( $transient = '' ) {
 	}
 
 	foreach ( tml_get_extensions() as $extension ) {
-		$response = tml_extension_api_call( $extension->get_store_url(), array(
-			'license' => $extension->get_license_key(),
-			'item_id' => $extension->get_item_id(),
-			'slug'    => $extension->get_name(),
-		) );
+		$response = tml_extension_api_call(
+			$extension->get_store_url(),
+			array(
+				'license' => $extension->get_license_key(),
+				'item_id' => $extension->get_item_id(),
+				'slug'    => $extension->get_name(),
+			)
+		);
 
 		if ( is_object( $response ) ) {
 			$basename = $extension->get_basename();
@@ -148,15 +156,15 @@ function tml_add_extension_data_to_plugins_transient( $transient = '' ) {
 			$update = (object) array(
 				'slug'             => $extension->get_name(),
 				'plugin'           => $basename,
-				'new_version'      => isset( $response->new_version )      ? $response->new_version      : ( isset( $response->version )       ? $response->version       : '' ),
-				'url'              => isset( $response->url )              ? $response->url              : ( isset( $response->homepage )      ? $response->homepage      : '' ),
-				'package'          => isset( $response->package )          ? $response->package          : ( isset( $response->download_link ) ? $response->download_link : '' ),
-				'icons'            => isset( $response->icons )            ? $response->icons            : array(),
-				'banners'          => isset( $response->banners )          ? $response->banners          : array(),
-				'banners_rtl'      => isset( $response->banners_rtl )      ? $response->banners_rtl      : array(),
-				'requires'         => isset( $response->requires )         ? $response->requires         : '',
-				'tested'           => isset( $response->tested )           ? $response->tested           : '',
-				'requires_php'     => isset( $response->requires_php )     ? $response->requires_php     : '',
+				'new_version'      => isset( $response->new_version ) ? $response->new_version : ( isset( $response->version ) ? $response->version : '' ),
+				'url'              => isset( $response->url ) ? $response->url : ( isset( $response->homepage ) ? $response->homepage : '' ),
+				'package'          => isset( $response->package ) ? $response->package : ( isset( $response->download_link ) ? $response->download_link : '' ),
+				'icons'            => isset( $response->icons ) ? $response->icons : array(),
+				'banners'          => isset( $response->banners ) ? $response->banners : array(),
+				'banners_rtl'      => isset( $response->banners_rtl ) ? $response->banners_rtl : array(),
+				'requires'         => isset( $response->requires ) ? $response->requires : '',
+				'tested'           => isset( $response->tested ) ? $response->tested : '',
+				'requires_php'     => isset( $response->requires_php ) ? $response->requires_php : '',
 				'requires_plugins' => isset( $response->requires_plugins ) ? $response->requires_plugins : array(),
 			);
 
@@ -168,7 +176,7 @@ function tml_add_extension_data_to_plugins_transient( $transient = '' ) {
 			if ( ! empty( $update->new_version ) && version_compare( $extension->get_version(), $update->new_version, '<' ) ) {
 				$transient->response[ $basename ] = $update;
 
-			// This is just fetching the plugin information
+				// This is just fetching the plugin information
 			} else {
 				$transient->no_update[ $basename ] = $update;
 			}
@@ -190,15 +198,19 @@ function tml_add_extension_data_to_plugins_transient( $transient = '' ) {
  *                              extension doesn't exist or WP_Error on failure.
  */
 function tml_activate_extension_license( $extension ) {
-	if ( ! $extension = tml_get_extension( $extension ) ) {
+	$extension = tml_get_extension( $extension );
+	if ( ! $extension ) {
 		return false;
 	}
 
-	$response = tml_extension_api_call( $extension->get_store_url(), array(
-		'edd_action' => 'activate_license',
-		'license'    => $extension->get_license_key(),
-		'item_id'    => $extension->get_item_id(),
-	) );
+	$response = tml_extension_api_call(
+		$extension->get_store_url(),
+		array(
+			'edd_action' => 'activate_license',
+			'license'    => $extension->get_license_key(),
+			'item_id'    => $extension->get_item_id(),
+		)
+	);
 
 	if ( empty( $response ) ) {
 		return new WP_Error( 'http_error', __( 'An error occurred, please try again.', 'theme-my-login' ) );
@@ -206,34 +218,35 @@ function tml_activate_extension_license( $extension ) {
 
 	if ( false === $response->success ) {
 		switch ( $response->error ) {
-			case 'expired' :
+			case 'expired':
 				$message = sprintf(
+					/* translators: %s: License expiration date. */
 					__( 'Your license key expired on %s.', 'theme-my-login' ),
-					date_i18n( get_option( 'date_format' ), strtotime( $license_data->expires, current_time( 'timestamp' ) ) )
+					date_i18n( get_option( 'date_format' ), strtotime( $response->expires, time() ) )
 				);
 				break;
 
-			case 'disabled' :
+			case 'disabled':
 				$message = __( 'Your license key has been disabled.', 'theme-my-login' );
 				break;
 
-			case 'missing' :
-			case 'missing_url' :
-			case 'key_mismatch' :
-			case 'invalid_item_id' :
-			case 'item_name_mismatch' :
+			case 'missing':
+			case 'missing_url':
+			case 'key_mismatch':
+			case 'invalid_item_id':
+			case 'item_name_mismatch':
 				$message = __( 'Invalid license.', 'theme-my-login' );
 				break;
 
-			case 'no_activations_left' :
+			case 'no_activations_left':
 				$message = __( 'Your license key has reached its activation limit.', 'theme-my-login' );
 				break;
 
-			case 'license_not_activable' :
+			case 'license_not_activable':
 				$message = __( 'You are attempting to activate a bundle license. Please use the license that corresponds to the individual extension you are attemtping to activate.', 'theme-my-login' );
 				break;
 
-			default :
+			default:
 				$message = __( 'An error occurred, please try again.', 'theme-my-login' );
 				break;
 		}
@@ -253,25 +266,33 @@ function tml_activate_extension_license( $extension ) {
  *                              extension doesn't exist or WP_Error on failure.
  */
 function tml_deactivate_extension_license( $extension ) {
-	if ( ! $extension = tml_get_extension( $extension ) ) {
+	$extension = tml_get_extension( $extension );
+	if ( ! $extension ) {
 		return false;
 	}
 
-	$response = tml_extension_api_call( $extension->get_store_url(), array(
-		'edd_action' => 'deactivate_license',
-		'license'    => $extension->get_license_key(),
-		'item_id'    => $extension->get_item_id(),
-	) );
+	$response = tml_extension_api_call(
+		$extension->get_store_url(),
+		array(
+			'edd_action' => 'deactivate_license',
+			'license'    => $extension->get_license_key(),
+			'item_id'    => $extension->get_item_id(),
+		)
+	);
 
 	if ( empty( $response ) ) {
 		return new WP_Error( 'http_error', __( 'An error occurred, please try again.', 'theme-my-login' ) );
 	}
 
 	if ( false === $response->success ) {
-		return new WP_Error( 'deactivation_failed', sprintf(
-			__( 'Unable to deactivate license. Please deactivate it on <a href="%1$s" target="_blank">our site</a>.', 'theme-my-login' ),
-			'https://thememylogin.com/your-account/?action=license-keys'
-		) );
+		return new WP_Error(
+			'deactivation_failed',
+			sprintf(
+				/* translators: %1$s: URL to deactivate the license on thememylogin.com. */
+				__( 'Unable to deactivate license. Please deactivate it on <a href="%1$s" target="_blank">our site</a>.', 'theme-my-login' ),
+				'https://thememylogin.com/your-account/?action=license-keys'
+			)
+		);
 	}
 
 	return $response->license;
@@ -287,16 +308,20 @@ function tml_deactivate_extension_license( $extension ) {
  *                              extension doesn't exist or WP_Error on failure.
  */
 function tml_check_extension_license( $extension ) {
-	if ( ! $extension = tml_get_extension( $extension ) ) {
+	$extension = tml_get_extension( $extension );
+	if ( ! $extension ) {
 		return false;
 	}
 
-	$response = tml_extension_api_call( $extension->get_store_url(), array(
-		'edd_action' => 'check_license',
-		'license'    => $extension->get_license_key(),
-		'item_id'    => $extension->get_item_id(),
-		'url'        => home_url(),
-	) );
+	$response = tml_extension_api_call(
+		$extension->get_store_url(),
+		array(
+			'edd_action' => 'check_license',
+			'license'    => $extension->get_license_key(),
+			'item_id'    => $extension->get_item_id(),
+			'url'        => home_url(),
+		)
+	);
 
 	if ( empty( $response ) ) {
 		return new WP_Error( 'http_error', __( 'An error occurred, please try again.', 'theme-my-login' ) );
@@ -324,26 +349,33 @@ function tml_check_extension_license( $extension ) {
  * @return object|false The response object or false on failure.
  */
 function tml_extension_api_call( $url, $args = array() ) {
-	$args = wp_parse_args( $args, array(
-		'edd_action' => 'get_version',
-		'license'    => '',
-		'item_id'    => '',
-		'slug'       => '',
-		'url'        => '',
-		'beta'       => false,
-	) );
+	$args = wp_parse_args(
+		$args,
+		array(
+			'edd_action' => 'get_version',
+			'license'    => '',
+			'item_id'    => '',
+			'slug'       => '',
+			'url'        => '',
+			'beta'       => false,
+		)
+	);
 
+	// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- one-way hash input for a cache key, never unserialized; no object-injection risk.
 	$cache_key = md5( serialize( $args ) );
 
 	$response = wp_cache_get( $cache_key, 'tml_api_calls' );
 	if ( ! $response ) {
-		$response = wp_remote_post( $url, array(
-			'timeout'   => 30,
-			'sslverify' => true,
-			'body'      => $args,
-		) );
+		$response = wp_remote_post(
+			$url,
+			array(
+				'timeout'   => 30,
+				'sslverify' => true,
+				'body'      => $args,
+			)
+		);
 
-		if ( is_wp_error( $response ) || 200 != wp_remote_retrieve_response_code( $response ) ) {
+		if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
 			return false;
 		}
 

--- a/src/includes/forms.php
+++ b/src/includes/forms.php
@@ -29,63 +29,95 @@ function tml_register_default_forms() {
  * @since 7.0
  */
 function tml_register_login_form() {
+	// phpcs:disable WordPress.WP.I18n.MissingArgDomain -- these field labels intentionally reuse WP core's translated wp-login.php strings verbatim, not TML-specific strings.
 
-	tml_register_form( 'login', array(
-		'action'     => tml_get_action_url( 'login' ),
-		'attributes' => array_filter( array(
-			'data-ajax' => tml_use_ajax() ? 1 : 0,
-		) ),
-		'render_args' => isset( $_GET['checkemail'] ) ? array(
-			'show_form'  => false,
-			'show_links' => false,
-		) : array(),
-	) );
+	tml_register_form(
+		'login',
+		array(
+			'action'      => tml_get_action_url( 'login' ),
+			'attributes'  => array_filter(
+				array(
+					'data-ajax' => tml_use_ajax() ? 1 : 0,
+				)
+			),
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only: just toggles whether the login form itself is shown, not processed/acted on.
+			'render_args' => isset( $_GET['checkemail'] ) ? array(
+				'show_form'  => false,
+				'show_links' => false,
+			) : array(),
+		)
+	);
 
-	tml_add_form_field( 'login', 'log', array(
-		'type'       => 'text',
-		'label'      => tml_get_username_label( 'login' ),
-		'value'      => tml_get_request_value( 'log', 'post' ),
-		'id'         => 'user_login',
-		'attributes' => array(
-			'autocapitalize' => 'off',
-		),
-		'priority'   => 10,
-	) );
+	tml_add_form_field(
+		'login',
+		'log',
+		array(
+			'type'       => 'text',
+			'label'      => tml_get_username_label( 'login' ),
+			'value'      => tml_get_request_value( 'log', 'post' ),
+			'id'         => 'user_login',
+			'attributes' => array(
+				'autocapitalize' => 'off',
+			),
+			'priority'   => 10,
+		)
+	);
 
-	tml_add_form_field( 'login', 'pwd', array(
-		'type'     => 'password',
-		'label'    => __( 'Password' ),
-		'value'    => '',
-		'id'       => 'user_pass',
-		'priority' => 15,
-	) );
+	tml_add_form_field(
+		'login',
+		'pwd',
+		array(
+			'type'     => 'password',
+			'label'    => __( 'Password' ),
+			'value'    => '',
+			'id'       => 'user_pass',
+			'priority' => 15,
+		)
+	);
 
-	tml_add_form_field( 'login', 'login_form', array(
-		'type'     => 'action',
-		'priority' => 20,
-	) );
+	tml_add_form_field(
+		'login',
+		'login_form',
+		array(
+			'type'     => 'action',
+			'priority' => 20,
+		)
+	);
 
-	tml_add_form_field( 'login', 'rememberme', array(
-		'type'     => 'checkbox',
-		'label'    => __( 'Remember Me' ),
-		'value'    => 'forever',
-		'id'       => 'rememberme',
-		'priority' => 25,
-	) );
+	tml_add_form_field(
+		'login',
+		'rememberme',
+		array(
+			'type'     => 'checkbox',
+			'label'    => __( 'Remember Me' ),
+			'value'    => 'forever',
+			'id'       => 'rememberme',
+			'priority' => 25,
+		)
+	);
 
-	tml_add_form_field( 'login', 'submit', array(
-		'type'     => 'submit',
-		'value'    => __( 'Log In' ),
-		'priority' => 30,
-	) );
+	tml_add_form_field(
+		'login',
+		'submit',
+		array(
+			'type'     => 'submit',
+			'value'    => __( 'Log In' ),
+			'priority' => 30,
+		)
+	);
 
 	$redirect_to = tml_get_request_value( 'redirect_to' );
 
-	tml_add_form_field( 'login', 'redirect_to', array(
-		'type'     => 'hidden',
-		'value'    => ! empty( $redirect_to ) ? $redirect_to : admin_url(),
-		'priority' => 30,
-	) );
+	tml_add_form_field(
+		'login',
+		'redirect_to',
+		array(
+			'type'     => 'hidden',
+			'value'    => ! empty( $redirect_to ) ? $redirect_to : admin_url(),
+			'priority' => 30,
+		)
+	);
+	// phpcs:enable WordPress.WP.I18n.MissingArgDomain
 }
 
 /**
@@ -94,102 +126,153 @@ function tml_register_login_form() {
  * @since 7.0
  */
 function tml_register_registration_form() {
+	// phpcs:disable WordPress.WP.I18n.MissingArgDomain -- these field labels intentionally reuse WP core's translated wp-login.php strings verbatim, not TML-specific strings.
 
-	tml_register_form( 'register', array(
-		'action'     => tml_get_action_url( 'register' ),
-		'attributes' => array_filter( array(
-			'novalidate' => 'novalidate',
-			'data-ajax' => tml_use_ajax() ? 1 : 0,
-		) ),
-	) );
+	tml_register_form(
+		'register',
+		array(
+			'action'     => tml_get_action_url( 'register' ),
+			'attributes' => array_filter(
+				array(
+					'novalidate' => 'novalidate',
+					'data-ajax'  => tml_use_ajax() ? 1 : 0,
+				)
+			),
+		)
+	);
 
 	if ( tml_is_default_registration_type() ) {
-		tml_add_form_field( 'register', 'user_login', array(
-			'type'       => 'text',
-			'label'      => __( 'Username' ),
-			'value'      => tml_get_request_value( 'user_login', 'post' ),
-			'id'         => 'user_login',
-			'attributes' => array(
-				'autocapitalize' => 'off',
-			),
-			'priority'   => 10,
-		) );
+		tml_add_form_field(
+			'register',
+			'user_login',
+			array(
+				'type'       => 'text',
+				'label'      => __( 'Username' ),
+				'value'      => tml_get_request_value( 'user_login', 'post' ),
+				'id'         => 'user_login',
+				'attributes' => array(
+					'autocapitalize' => 'off',
+				),
+				'priority'   => 10,
+			)
+		);
 	} else {
-		tml_add_form_field( 'register', 'user_login', array(
-			'type'     => 'hidden',
-			'label'    => '',
-			'value'    => 'user' . md5( microtime() ),
-			'id'       => 'user_login',
-			'priority' => 10,
-		) );
+		tml_add_form_field(
+			'register',
+			'user_login',
+			array(
+				'type'     => 'hidden',
+				'label'    => '',
+				'value'    => 'user' . md5( microtime() ),
+				'id'       => 'user_login',
+				'priority' => 10,
+			)
+		);
 	}
 
-	tml_add_form_field( 'register', 'user_email', array(
-		'type'     => 'email',
-		'label'    => __( 'Email' ),
-		'value'    => tml_get_request_value( 'user_email', 'post' ),
-		'id'       => 'user_email',
-		'priority' => 15,
-	) );
+	tml_add_form_field(
+		'register',
+		'user_email',
+		array(
+			'type'     => 'email',
+			'label'    => __( 'Email' ),
+			'value'    => tml_get_request_value( 'user_email', 'post' ),
+			'id'       => 'user_email',
+			'priority' => 15,
+		)
+	);
 
 	if ( tml_allow_user_passwords() ) {
-		tml_add_form_field( 'register', 'user_pass1', array(
-			'type'       => 'password',
-			'label'      => __( 'Password' ),
-			'id'         => 'pass1',
-			'attributes' => array(
-				'autocomplete' => 'off',
-			),
-			'priority'   => 20,
-		) );
+		tml_add_form_field(
+			'register',
+			'user_pass1',
+			array(
+				'type'       => 'password',
+				'label'      => __( 'Password' ),
+				'id'         => 'pass1',
+				'attributes' => array(
+					'autocomplete' => 'off',
+				),
+				'priority'   => 20,
+			)
+		);
 
-		tml_add_form_field( 'register', 'user_pass2', array(
-			'type'       => 'password',
-			'label'      => __( 'Confirm Password', 'theme-my-login' ),
-			'id'         => 'pass2',
-			'attributes' => array(
-				'autocomplete' => 'off',
-			),
-			'priority'   => 20,
-		) );
+		tml_add_form_field(
+			'register',
+			'user_pass2',
+			array(
+				'type'       => 'password',
+				'label'      => __( 'Confirm Password', 'theme-my-login' ),
+				'id'         => 'pass2',
+				'attributes' => array(
+					'autocomplete' => 'off',
+				),
+				'priority'   => 20,
+			)
+		);
 
-		tml_add_form_field( 'register', 'indicator', array(
-			'type'     => 'custom',
-			'content'  => '<div id="pass-strength-result" class="hide-if-no-js" aria-live="polite">' . __( 'Strength indicator' ) . '</div>',
-			'priority' => 20,
-		) );
+		tml_add_form_field(
+			'register',
+			'indicator',
+			array(
+				'type'     => 'custom',
+				'content'  => '<div id="pass-strength-result" class="hide-if-no-js" aria-live="polite">' . __( 'Strength indicator' ) . '</div>',
+				'priority' => 20,
+			)
+		);
 
-		tml_add_form_field( 'register', 'indicator_hint', array(
-			'type'     => 'custom',
-			'content'  => '<p class="description indicator-hint">' . wp_get_password_hint() . '</p>',
-			'priority' => 20,
-		) );
+		tml_add_form_field(
+			'register',
+			'indicator_hint',
+			array(
+				'type'     => 'custom',
+				'content'  => '<p class="description indicator-hint">' . wp_get_password_hint() . '</p>',
+				'priority' => 20,
+			)
+		);
 	}
 
-	tml_add_form_field( 'register', 'register_form', array(
-		'type'     => 'action',
-		'priority' => 25,
-	) );
+	tml_add_form_field(
+		'register',
+		'register_form',
+		array(
+			'type'     => 'action',
+			'priority' => 25,
+		)
+	);
 
 	if ( ! tml_allow_user_passwords() ) {
-		tml_add_form_field( 'register', 'reg_passmail', array(
-			'type'     => 'custom',
-			'content'  => '<p id="reg_passmail">' . __( 'Registration confirmation will be emailed to you.' ) . '</p>',
-			'priority' => 30,
-		) );
+		tml_add_form_field(
+			'register',
+			'reg_passmail',
+			array(
+				'type'     => 'custom',
+				'content'  => '<p id="reg_passmail">' . __( 'Registration confirmation will be emailed to you.' ) . '</p>',
+				'priority' => 30,
+			)
+		);
 	}
 
-	tml_add_form_field( 'register', 'submit', array(
-		'type'     => 'submit',
-		'value'    => __( 'Register' ),
-		'priority' => 35,
-	) );
+	tml_add_form_field(
+		'register',
+		'submit',
+		array(
+			'type'     => 'submit',
+			'value'    => __( 'Register' ),
+			'priority' => 35,
+		)
+	);
 
-	tml_add_form_field( 'register', 'redirect_to', array(
-		'type'     => 'hidden',
-		'value'    => apply_filters( 'registration_redirect', tml_get_request_value( 'redirect_to' ) ),
-		'priority' => 35,
-	) );
+	tml_add_form_field(
+		'register',
+		'redirect_to',
+		array(
+			'type'     => 'hidden',
+			'value'    => apply_filters( 'registration_redirect', tml_get_request_value( 'redirect_to' ) ),
+			'priority' => 35,
+		)
+	);
+	// phpcs:enable WordPress.WP.I18n.MissingArgDomain
 }
 
 /**
@@ -198,47 +281,74 @@ function tml_register_registration_form() {
  * @since 7.0
  */
 function tml_register_lost_password_form() {
+	// phpcs:disable WordPress.WP.I18n.MissingArgDomain -- these field labels intentionally reuse WP core's translated wp-login.php strings verbatim, not TML-specific strings.
 
-	tml_register_form( 'lostpassword', array(
-		'action'     => tml_get_action_url( 'lostpassword' ),
-		'attributes' => array_filter( array(
-			'data-ajax' => tml_use_ajax() ? 1 : 0,
-		) ),
-	) );
+	tml_register_form(
+		'lostpassword',
+		array(
+			'action'     => tml_get_action_url( 'lostpassword' ),
+			'attributes' => array_filter(
+				array(
+					'data-ajax' => tml_use_ajax() ? 1 : 0,
+				)
+			),
+		)
+	);
 
-	tml_add_form_field( 'lostpassword', 'message', array(
-		'type' => 'custom',
-		'content' => '<p class="tml-message">' . __('Please enter your username or email address. You will receive an email message with instructions on how to reset your password.') . '</p>',
-		'priority' => 10,
-	) );
+	tml_add_form_field(
+		'lostpassword',
+		'message',
+		array(
+			'type'     => 'custom',
+			'content'  => '<p class="tml-message">' . __( 'Please enter your username or email address. You will receive an email message with instructions on how to reset your password.' ) . '</p>',
+			'priority' => 10,
+		)
+	);
 
-	tml_add_form_field( 'lostpassword', 'user_login', array(
-		'type'       => 'text',
-		'label'      => tml_get_username_label( 'lostpassword' ),
-		'value'      => tml_get_request_value( 'user_login', 'post' ),
-		'id'         => 'user_login',
-		'attributes' => array(
-			'autocapitalize' => 'off',
-		),
-		'priority'   => 10,
-	) );
+	tml_add_form_field(
+		'lostpassword',
+		'user_login',
+		array(
+			'type'       => 'text',
+			'label'      => tml_get_username_label( 'lostpassword' ),
+			'value'      => tml_get_request_value( 'user_login', 'post' ),
+			'id'         => 'user_login',
+			'attributes' => array(
+				'autocapitalize' => 'off',
+			),
+			'priority'   => 10,
+		)
+	);
 
-	tml_add_form_field( 'lostpassword', 'lostpassword_form', array(
-		'type'     => 'action',
-		'priority' => 15,
-	) );
+	tml_add_form_field(
+		'lostpassword',
+		'lostpassword_form',
+		array(
+			'type'     => 'action',
+			'priority' => 15,
+		)
+	);
 
-	tml_add_form_field( 'lostpassword', 'submit', array(
-		'type'     => 'submit',
-		'value'    => __( 'Get New Password' ),
-		'priority' => 20,
-	) );
+	tml_add_form_field(
+		'lostpassword',
+		'submit',
+		array(
+			'type'     => 'submit',
+			'value'    => __( 'Get New Password' ),
+			'priority' => 20,
+		)
+	);
 
-	tml_add_form_field( 'lostpassword', 'redirect_to', array(
-		'type'     => 'hidden',
-		'value'    => apply_filters( 'lostpassword_redirect', tml_get_request_value( 'redirect_to' ) ),
-		'priority' => 20,
-	) );
+	tml_add_form_field(
+		'lostpassword',
+		'redirect_to',
+		array(
+			'type'     => 'hidden',
+			'value'    => apply_filters( 'lostpassword_redirect', tml_get_request_value( 'redirect_to' ) ),
+			'priority' => 20,
+		)
+	);
+	// phpcs:enable WordPress.WP.I18n.MissingArgDomain
 }
 
 /**
@@ -247,72 +357,106 @@ function tml_register_lost_password_form() {
  * @since 7.0
  */
 function tml_register_password_reset_form() {
+	// phpcs:disable WordPress.WP.I18n.MissingArgDomain -- these field labels intentionally reuse WP core's translated wp-login.php strings verbatim, not TML-specific strings.
 
-	tml_register_form( 'resetpass', array(
-		'action'      => tml_get_action_url( 'resetpass' ),
-		'attributes'  => array(
-			'autocomplete' => 'off',
-		),
-		'render_args' => array(
-			'show_links' => false,
-		),
-	) );
+	tml_register_form(
+		'resetpass',
+		array(
+			'action'      => tml_get_action_url( 'resetpass' ),
+			'attributes'  => array(
+				'autocomplete' => 'off',
+			),
+			'render_args' => array(
+				'show_links' => false,
+			),
+		)
+	);
 
-	tml_add_form_field( 'resetpass', 'pass1', array(
-		'type'       => 'password',
-		'label'      => __( 'New password' ),
-		'id'         => 'pass1',
-		'attributes' => array(
-			'autocomplete' => 'off',
-			'aria-describedby' => 'pass-strength-result',
-		),
-		'priority'   => 10,
-	) );
+	tml_add_form_field(
+		'resetpass',
+		'pass1',
+		array(
+			'type'       => 'password',
+			'label'      => __( 'New password' ),
+			'id'         => 'pass1',
+			'attributes' => array(
+				'autocomplete'     => 'off',
+				'aria-describedby' => 'pass-strength-result',
+			),
+			'priority'   => 10,
+		)
+	);
 
-	tml_add_form_field( 'resetpass', 'pass2', array(
-		'type'       => 'password',
-		'label'      => __( 'Confirm new password' ),
-		'id'         => 'pass2',
-		'attributes' => array(
-			'autocomplete' => 'off',
-			'aria-describedby' => 'pass-strength-result',
-		),
-		'priority'   => 10,
-	) );
+	tml_add_form_field(
+		'resetpass',
+		'pass2',
+		array(
+			'type'       => 'password',
+			'label'      => __( 'Confirm new password' ),
+			'id'         => 'pass2',
+			'attributes' => array(
+				'autocomplete'     => 'off',
+				'aria-describedby' => 'pass-strength-result',
+			),
+			'priority'   => 10,
+		)
+	);
 
-	tml_add_form_field( 'resetpass', 'indicator', array(
-		'type'     => 'custom',
-		'content'  => '<div id="pass-strength-result" class="hide-if-no-js" aria-live="polite">' . __( 'Strength indicator' ) . '</div>',
-		'priority' => 10,
-	) );
+	tml_add_form_field(
+		'resetpass',
+		'indicator',
+		array(
+			'type'     => 'custom',
+			'content'  => '<div id="pass-strength-result" class="hide-if-no-js" aria-live="polite">' . __( 'Strength indicator' ) . '</div>',
+			'priority' => 10,
+		)
+	);
 
-	tml_add_form_field( 'resetpass', 'indicator_hint', array(
-		'type'     => 'custom',
-		'content'  => '<p class="description indicator-hint">' . wp_get_password_hint() . '</p>',
-		'priority' => 10,
-	) );
+	tml_add_form_field(
+		'resetpass',
+		'indicator_hint',
+		array(
+			'type'     => 'custom',
+			'content'  => '<p class="description indicator-hint">' . wp_get_password_hint() . '</p>',
+			'priority' => 10,
+		)
+	);
 
-	tml_add_form_field( 'resetpass', 'resetpass_form', array(
-		'type'        => 'action',
-		'priority'    => 15,
-		'render_args' => array( wp_get_current_user() )
-	) );
+	tml_add_form_field(
+		'resetpass',
+		'resetpass_form',
+		array(
+			'type'        => 'action',
+			'priority'    => 15,
+			'render_args' => array( wp_get_current_user() ),
+		)
+	);
 
-	tml_add_form_field( 'resetpass', 'submit', array(
-		'type'     => 'submit',
-		'value'    => __( 'Save Password' ),
-		'priority' => 20,
-	) );
+	tml_add_form_field(
+		'resetpass',
+		'submit',
+		array(
+			'type'     => 'submit',
+			'value'    => __( 'Save Password' ),
+			'priority' => 20,
+		)
+	);
+
+	// phpcs:enable WordPress.WP.I18n.MissingArgDomain
 
 	$rp_cookie = 'wp-resetpass-' . COOKIEHASH;
 	if ( isset( $_COOKIE[ $rp_cookie ] ) && 0 < strpos( $_COOKIE[ $rp_cookie ], ':' ) ) {
 		list( $rp_login, $rp_key ) = explode( ':', wp_unslash( $_COOKIE[ $rp_cookie ] ), 2 );
 
-		tml_add_form_field( 'resetpass', 'rp_key', array(
-			'type'     => 'hidden',
-			'value'    => $rp_key,
-			'priority' => 20,
-		) );
+		tml_add_form_field(
+			'resetpass',
+			'rp_key',
+			array(
+				'type'     => 'hidden',
+				'value'    => $rp_key,
+				'priority' => 20,
+			)
+		);
 	}
 }
 
@@ -362,7 +506,8 @@ function tml_get_form( $form = '' ) {
 	}
 
 	if ( empty( $form ) ) {
-		if ( $action = tml_get_action() ) {
+		$action = tml_get_action();
+		if ( $action ) {
 			$form = $action->get_name();
 		}
 	}
@@ -407,7 +552,8 @@ function tml_form_exists( $form ) {
  */
 function tml_add_form_field( $form, $field, $args = array() ) {
 
-	if ( ! $form = tml_get_form( $form ) ) {
+	$form = tml_get_form( $form );
+	if ( ! $form ) {
 		return;
 	}
 
@@ -428,7 +574,8 @@ function tml_add_form_field( $form, $field, $args = array() ) {
  */
 function tml_remove_form_field( $form, $field ) {
 
-	if ( ! $form = tml_get_form( $form ) ) {
+	$form = tml_get_form( $form );
+	if ( ! $form ) {
 		return;
 	}
 
@@ -446,7 +593,8 @@ function tml_remove_form_field( $form, $field ) {
  */
 function tml_get_form_field( $form, $field ) {
 
-	if ( ! $form = tml_get_form( $form ) ) {
+	$form = tml_get_form( $form );
+	if ( ! $form ) {
 		return false;
 	}
 
@@ -463,7 +611,8 @@ function tml_get_form_field( $form, $field ) {
  */
 function tml_get_form_fields( $form ) {
 
-	if ( ! $form = tml_get_form( $form ) ) {
+	$form = tml_get_form( $form );
+	if ( ! $form ) {
 		return false;
 	}
 

--- a/src/includes/functions.php
+++ b/src/includes/functions.php
@@ -34,9 +34,9 @@ function tml_parse_request( $wp ) {
 	$action = $wp->query_vars['action'];
 
 	// Fix some alias actions
-	if ( 'retrievepassword' == $action ) {
+	if ( 'retrievepassword' === $action ) {
 		$action = 'lostpassword';
-	} elseif ( 'rp' == $action ) {
+	} elseif ( 'rp' === $action ) {
 		$action = 'resetpass';
 	}
 
@@ -56,7 +56,7 @@ function tml_parse_request( $wp ) {
 	}
 
 	// Set the proper action
-	if ( $action != $wp->query_vars['action'] ) {
+	if ( $action !== $wp->query_vars['action'] ) {
 		$wp->set_query_var( 'action', $action );
 	}
 }
@@ -120,7 +120,8 @@ function tml_the_posts( $posts, $wp_query ) {
 		return $posts;
 	}
 
-	if ( ! $post = tml_action_has_page() ) {
+	$post = tml_action_has_page();
+	if ( ! $post ) {
 		// Fake a post
 		$post = array(
 			'ID'             => 0,
@@ -150,14 +151,14 @@ function tml_remove_default_actions_and_filters() {
 	}
 
 	// Remove actions
-	remove_action( 'wp_head', 'feed_links',                       2 );
-	remove_action( 'wp_head', 'feed_links_extra',                 3 );
-	remove_action( 'wp_head', 'rsd_link',                        10 );
-	remove_action( 'wp_head', 'wlwmanifest_link',                10 );
-	remove_action( 'wp_head', 'parent_post_rel_link',            10 );
-	remove_action( 'wp_head', 'start_post_rel_link',             10 );
+	remove_action( 'wp_head', 'feed_links', 2 );
+	remove_action( 'wp_head', 'feed_links_extra', 3 );
+	remove_action( 'wp_head', 'rsd_link', 10 );
+	remove_action( 'wp_head', 'wlwmanifest_link', 10 );
+	remove_action( 'wp_head', 'parent_post_rel_link', 10 );
+	remove_action( 'wp_head', 'start_post_rel_link', 10 );
 	remove_action( 'wp_head', 'adjacent_posts_rel_link_wp_head', 10 );
-	remove_action( 'wp_head', 'rel_canonical',                   10 );
+	remove_action( 'wp_head', 'rel_canonical', 10 );
 
 	// Remove filters
 	remove_filter( 'template_redirect', 'redirect_canonical' );
@@ -173,11 +174,12 @@ function tml_remove_default_actions_and_filters() {
  */
 function tml_page_template( $template = 'page.php' ) {
 	// Don't stomp on block themes
-	if ( ABSPATH . WPINC . '/template-canvas.php' == $template) {
+	if ( ABSPATH . WPINC . '/template-canvas.php' === $template ) {
 		return $template;
 	}
 
-	if ( ! $action = tml_get_action() ) {
+	$action = tml_get_action();
+	if ( ! $action ) {
 		return $template;
 	}
 
@@ -209,7 +211,8 @@ function tml_page_template( $template = 'page.php' ) {
 	 */
 	$templates = apply_filters( 'tml_page_templates', $templates );
 
-	if ( $tml_template = locate_template( $templates ) ) {
+	$tml_template = locate_template( $templates );
+	if ( $tml_template ) {
 		return $tml_template;
 	}
 
@@ -225,7 +228,8 @@ function tml_page_template( $template = 'page.php' ) {
  * @return array The body classes.
  */
 function tml_body_class( $classes ) {
-	if ( $action = tml_get_action() ) {
+	$action = tml_get_action();
+	if ( $action ) {
 		$classes[] = 'tml-action';
 		$classes[] = 'tml-action-' . $action->get_name();
 	}
@@ -275,10 +279,13 @@ function tml_enqueue_scripts() {
 	 *
 	 * @param array $data The main TML script data.
 	 */
-	$data = apply_filters( 'tml_script_data', array(
-		'action' => tml_is_action() ? tml_get_action()->get_name() : '',
-		'errors' => tml_get_errors()->get_error_codes(),
-	) );
+	$data = apply_filters(
+		'tml_script_data',
+		array(
+			'action' => tml_is_action() ? tml_get_action()->get_name() : '',
+			'errors' => tml_get_errors()->get_error_codes(),
+		)
+	);
 
 	wp_localize_script( 'theme-my-login', 'themeMyLogin', $data );
 
@@ -348,8 +355,9 @@ function tml_add_rewrite_rules() {
 		return;
 	}
 	foreach ( tml_get_actions() as $action ) {
-		$url = 'index.php?action=' . $action->get_name();
-		if ( $page = tml_action_has_page( $action ) ) {
+		$url  = 'index.php?action=' . $action->get_name();
+		$page = tml_action_has_page( $action );
+		if ( $page ) {
 			$url .= '&pagename=' . get_page_uri( $page );
 		}
 		add_rewrite_rule( tml_get_action_slug( $action ) . '/?$', $url, 'top' );
@@ -382,7 +390,7 @@ function tml_filter_site_url( $url, $path, $scheme ) {
 	global $pagenow;
 
 	// Bail if currently visiting wp-login.php
-	if ( 'wp-login.php' == $pagenow ) {
+	if ( 'wp-login.php' === $pagenow ) {
 		return $url;
 	}
 
@@ -392,7 +400,7 @@ function tml_filter_site_url( $url, $path, $scheme ) {
 	}
 
 	// Parse the URL
-	$parsed_url = parse_url( $url );
+	$parsed_url = wp_parse_url( $url );
 
 	// Determine the path
 	$path = '';
@@ -420,14 +428,14 @@ function tml_filter_site_url( $url, $path, $scheme ) {
 
 	// Determine the action
 	switch ( $path ) {
-		case 'wp-login.php' :
+		case 'wp-login.php':
 			// Determine the action
 			$action = isset( $query['action'] ) ? $query['action'] : 'login';
 
 			// Fix some alias actions
-			if ( 'retrievepassword' == $action ) {
+			if ( 'retrievepassword' === $action ) {
 				$action = 'lostpassword';
-			} elseif ( 'rp' == $action ) {
+			} elseif ( 'rp' === $action ) {
 				$action = 'resetpass';
 			}
 
@@ -435,15 +443,15 @@ function tml_filter_site_url( $url, $path, $scheme ) {
 			unset( $query['action'] );
 			break;
 
-		case 'wp-signup.php' :
+		case 'wp-signup.php':
 			$action = 'signup';
 			break;
 
-		case 'wp-activate.php' :
+		case 'wp-activate.php':
 			$action = 'activate';
 			break;
 
-		default :
+		default:
 			return $url;
 	}
 
@@ -453,7 +461,8 @@ function tml_filter_site_url( $url, $path, $scheme ) {
 	}
 
 	// Get the URL
-	$url = tml_get_action_url( $action, $scheme, 'network_site_url' == current_filter() );
+	$is_network = ( 'network_site_url' === current_filter() );
+	$url        = tml_get_action_url( $action, $scheme, $is_network );
 
 	// Add the query
 	$url = add_query_arg( $query, $url );
@@ -484,7 +493,7 @@ function tml_filter_logout_url( $url, $redirect ) {
 
 	// Add the redirect query argument if needed
 	if ( ! empty( $redirect ) ) {
-		$url = add_query_arg( 'redirect_to', urlencode( $redirect ), $url );
+		$url = add_query_arg( 'redirect_to', urlencode( $redirect ), $url ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.urlencode_urlencode -- matches wp_logout_url()'s own encoding of the redirect_to arg.
 	}
 
 	// Add the nonce
@@ -508,7 +517,7 @@ function tml_filter_lostpassword_url( $url, $redirect ) {
 	global $pagenow;
 
 	// Bail if currently visiting wp-login.php
-	if ( 'wp-login.php' == $pagenow ) {
+	if ( 'wp-login.php' === $pagenow ) {
 		return $url;
 	}
 
@@ -522,7 +531,7 @@ function tml_filter_lostpassword_url( $url, $redirect ) {
 
 	// Add the redirect query argument if needed
 	if ( ! empty( $redirect ) ) {
-		$url = add_query_arg( 'redirect_to', urlencode( $redirect ), $url );
+		$url = add_query_arg( 'redirect_to', urlencode( $redirect ), $url ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.urlencode_urlencode -- matches wp_lostpassword_url()'s own encoding of the redirect_to arg.
 	}
 
 	return $url;
@@ -572,7 +581,7 @@ function tml_filter_comments_array( $comments ) {
 function tml_filter_customize_nav_menu_available_item_types( $item_types ) {
 	$item_types[] = array(
 		'title'      => __( 'Theme My Login Actions', 'theme-my-login' ),
-		'type_label' => __( 'Theme My Login Action',  'theme-my-login' ),
+		'type_label' => __( 'Theme My Login Action', 'theme-my-login' ),
 		'type'       => 'tml_action',
 		'object'     => 'tml_action',
 	);
@@ -590,8 +599,8 @@ function tml_filter_customize_nav_menu_available_item_types( $item_types ) {
  * @param int    $page   The current page.
  * @return array The available items.
  */
-function tml_filter_customize_nav_menu_available_items( $items, $type, $object, $page ) {
-	if ( 'tml_action' == $type && 0 == $page ) {
+function tml_filter_customize_nav_menu_available_items( $items, $type, $object, $page ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.objectFound -- matches the customize_nav_menu_available_items filter's documented parameter name.
+	if ( 'tml_action' === $type && 0 === $page ) {
 		foreach ( tml_get_actions() as $action ) {
 			if ( ! $action->show_in_nav_menus ) {
 				continue;
@@ -639,15 +648,16 @@ function tml_setup_nav_menu_item( $menu_item ) {
 			'xfn'              => '',
 		);
 
-	// Existing menu item
-	} elseif ( 'tml_action' == $menu_item->type ) {
+		// Existing menu item
+	} elseif ( 'tml_action' === $menu_item->type ) {
 		$menu_item->object_id  = $menu_item->ID;
 		$menu_item->type_label = __( 'TML Action', 'theme-my-login' );
-		if ( ! $action = tml_get_action( $menu_item->object ) ) {
+		$action                = tml_get_action( $menu_item->object );
+		if ( ! $action ) {
 			$menu_item->_invalid = true;
 		} else {
 			$menu_item->url = $action->get_url();
-			if ( 'logout' == $menu_item->object ) {
+			if ( 'logout' === $menu_item->object ) {
 				$menu_item->url = wp_nonce_url( $menu_item->url, 'log-out' );
 			}
 			if ( ! is_admin() && ! $action->show_nav_menu_item ) {
@@ -655,11 +665,12 @@ function tml_setup_nav_menu_item( $menu_item ) {
 			}
 		}
 
-	// Legacy menu item
-	} elseif ( 'page' == $menu_item->object ) {
-		$slug = get_post_field( 'post_name', $menu_item->object_id );
-		if ( $action = tml_get_action( $slug ) ) {
-			if ( 'logout' == $action->get_name() ) {
+		// Legacy menu item
+	} elseif ( 'page' === $menu_item->object ) {
+		$slug   = get_post_field( 'post_name', $menu_item->object_id );
+		$action = tml_get_action( $slug );
+		if ( $action ) {
+			if ( 'logout' === $action->get_name() ) {
 				$menu_item->url = wp_nonce_url( $action->get_url(), 'log-out' );
 			}
 			if ( ! is_admin() && ! $action->show_nav_menu_item ) {
@@ -681,7 +692,7 @@ function tml_setup_nav_menu_item( $menu_item ) {
  * @return array The nav menu item classes.
  */
 function tml_nav_menu_css_class( $classes, $item ) {
-	if ( 'tml_action' == $item->type ) {
+	if ( 'tml_action' === $item->type ) {
 		if ( tml_is_action( $item->object ) ) {
 			$classes[] = 'current-menu-item';
 			$classes[] = 'current_page_item';
@@ -699,6 +710,7 @@ function tml_nav_menu_css_class( $classes, $item ) {
  * @return WP_Error The registration errors.
  */
 function tml_validate_new_user_password( $errors = null ) {
+	// phpcs:disable WordPress.Security.NonceVerification.Missing -- mirrors WP core's own registration password validation (register_new_user()), which has no nonce of its own.
 
 	if ( empty( $errors ) ) {
 		$errors = new WP_Error();
@@ -708,13 +720,14 @@ function tml_validate_new_user_password( $errors = null ) {
 		if ( empty( $_POST['user_pass1'] ) || empty( $_POST['user_pass2'] ) ) {
 			$errors->add( 'empty_password', __( '<strong>Error:</strong> Please enter a password.', 'theme-my-login' ) );
 
-		} elseif ( false !== strpos( stripslashes( $_POST['user_pass1'] ), "\\" ) ) {
+		} elseif ( false !== strpos( stripslashes( $_POST['user_pass1'] ), '\\' ) ) {
 			$errors->add( 'password_backslash', __( '<strong>Error:</strong> Passwords may not contain the character "\\".', 'theme-my-login' ) );
 
 		} elseif ( $_POST['user_pass1'] !== $_POST['user_pass2'] ) {
 			$errors->add( 'password_mismatch', __( '<strong>Error:</strong> Passwords don&#8217;t match. Please enter the same password in both password fields.', 'theme-my-login' ) );
 		}
 	}
+	// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 	return $errors;
 }
@@ -743,11 +756,13 @@ function tml_add_password_notice_to_new_user_notification_email( $email ) {
  * @return string The sanitized user login.
  */
 function tml_set_user_login( $sanitized_user_login ) {
+	// phpcs:disable WordPress.Security.NonceVerification.Missing -- mirrors WP core's own registration processing (register_new_user()), which has no nonce of its own.
 	if ( tml_is_email_registration_type() && tml_is_post_request() ) {
-		if ( isset( $_POST['user_login'] ) && sanitize_user( $_POST['user_login'] ) == $sanitized_user_login && isset( $_POST['user_email'] ) ) {
+		if ( isset( $_POST['user_login'] ) && sanitize_user( $_POST['user_login'] ) === $sanitized_user_login && isset( $_POST['user_email'] ) ) {
 			$sanitized_user_login = sanitize_user( $_POST['user_email'] );
 		}
 	}
+	// phpcs:enable WordPress.Security.NonceVerification.Missing
 	return $sanitized_user_login;
 }
 
@@ -798,6 +813,7 @@ function tml_get_username_label( $action = '' ) {
 		$action = tml_get_action();
 	}
 
+	// phpcs:disable WordPress.WP.I18n.MissingArgDomain -- these labels intentionally reuse WP core's translated strings verbatim, not TML-specific strings.
 	switch ( $action ) {
 		case 'register':
 			$label = __( 'Username' );
@@ -814,6 +830,7 @@ function tml_get_username_label( $action = '' ) {
 				$label = __( 'Username or Email Address' );
 			}
 	}
+	// phpcs:enable WordPress.WP.I18n.MissingArgDomain
 
 	return apply_filters( 'tml_get_username_label', $label, $action );
 }
@@ -828,9 +845,9 @@ function tml_get_username_label( $action = '' ) {
  * @param string                $password
  * @return null|WP_User|WP_Error
  */
-function tml_enforce_login_type( $user, $username, $password ) {
-	if ( tml_is_email_login_type() && null == $user ) {
-		return new WP_Error( 'invalid_email', __( 'Unknown email address. Check again or try your username.' ) );
+function tml_enforce_login_type( $user, $username, $password ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $username/$password are unused but required by the authenticate filter signature.
+	if ( tml_is_email_login_type() && null === $user ) {
+		return new WP_Error( 'invalid_email', __( 'Unknown email address. Check again or try your username.' ) ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated string verbatim (see wp-includes/user.php), not a TML-specific string.
 	}
 	return $user;
 }
@@ -847,11 +864,13 @@ function tml_set_new_user_password( $user_id ) {
 		return;
 	}
 
+	// phpcs:disable WordPress.Security.NonceVerification.Missing -- mirrors WP core's own registration password handling (register_new_user()), which has no nonce of its own.
 	if ( empty( $_POST['user_pass1'] ) ) {
 		return;
 	}
 
 	wp_set_password( $_POST['user_pass1'], $user_id );
+	// phpcs:enable WordPress.Security.NonceVerification.Missing
 	update_user_option( $user_id, 'default_password_nag', false, true );
 }
 
@@ -867,7 +886,7 @@ function tml_handle_auto_login( $user_id ) {
 		return;
 	}
 
-	if ( 'wpmu_activate_blog' == current_filter() ) {
+	if ( 'wpmu_activate_blog' === current_filter() ) {
 		$user_id = func_get_arg( 1 );
 	}
 
@@ -908,8 +927,8 @@ function tml_send_new_user_notifications( $user_id, $notify = 'both' ) {
 	if ( empty( $notify ) ) {
 		$notify = 'admin';
 
-	// Set to admin if set to both and user is disabled
-	} elseif ( 'both' == $notify ) {
+		// Set to admin if set to both and user is disabled
+	} elseif ( 'both' === $notify ) {
 		if ( ! $send_user_notification ) {
 			$notify = 'admin';
 		} elseif ( ! $send_admin_notification ) {
@@ -918,11 +937,11 @@ function tml_send_new_user_notifications( $user_id, $notify = 'both' ) {
 	}
 
 	// Bail if type is admin and it is disabled
-	if ( 'admin' == $notify && ! $send_admin_notification ) {
+	if ( 'admin' === $notify && ! $send_admin_notification ) {
 		return;
 
-	// Bail if type is user and it is disabled
-	} elseif ( 'user' == $notify && ! $send_user_notification ) {
+		// Bail if type is user and it is disabled
+	} elseif ( 'user' === $notify && ! $send_user_notification ) {
 		return;
 	}
 
@@ -939,7 +958,8 @@ function tml_send_new_user_notifications( $user_id, $notify = 'both' ) {
  * @param string $severity The error severity.
  */
 function tml_add_error( $code, $message, $data = '' ) {
-	if ( ! $form = tml_get_form() ) {
+	$form = tml_get_form();
+	if ( ! $form ) {
 		return;
 	}
 	$form->add_error( $code, $message, $data );
@@ -953,8 +973,9 @@ function tml_add_error( $code, $message, $data = '' ) {
  * @return WP_Error
  */
 function tml_get_errors() {
-	if ( ! $form = tml_get_form() ) {
-		return new WP_Error;
+	$form = tml_get_form();
+	if ( ! $form ) {
+		return new WP_Error();
 	}
 	return $form->get_errors();
 }
@@ -967,7 +988,8 @@ function tml_get_errors() {
  * @param WP_Error $errors The errors.
  */
 function tml_set_errors( WP_Error $errors ) {
-	if ( ! $form = tml_get_form() ) {
+	$form = tml_get_form();
+	if ( ! $form ) {
 		return;
 	}
 	$form->set_errors( $errors );
@@ -981,7 +1003,8 @@ function tml_set_errors( WP_Error $errors ) {
  * @return bool
  */
 function tml_has_errors() {
-	if ( ! $form = tml_get_form() ) {
+	$form = tml_get_form();
+	if ( ! $form ) {
 		return false;
 	}
 	return $form->has_errors();
@@ -996,7 +1019,7 @@ function tml_has_errors() {
  * @param mixed  $default The value to return if the property is not set.
  * @return mixed The property value or $default if not set.
  */
-function tml_get_data( $name, $default = false ) {
+function tml_get_data( $name, $default = false ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.defaultFound -- public API parameter name, renaming risks breaking PHP 8 named-argument callers.
 	return theme_my_login()->get_data( $name, $default );
 }
 
@@ -1023,16 +1046,18 @@ function tml_set_data( $name, $value = '' ) {
  * @return mixed The requested value.
  */
 function tml_get_request_value( $key, $type = 'any' ) {
-	$type  = strtoupper( $type );
-	if ( 'POST' == $type && array_key_exists( $key, $_POST ) ) {
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing -- generic request-value accessor used in both nonce-protected and read-only contexts; verification is the caller's responsibility.
+	$type = strtoupper( $type );
+	if ( 'POST' === $type && array_key_exists( $key, $_POST ) ) {
 		$value = $_POST[ $key ];
-	} elseif ( 'GET' == $type && array_key_exists( $key, $_GET ) ) {
+	} elseif ( 'GET' === $type && array_key_exists( $key, $_GET ) ) {
 		$value = $_GET[ $key ];
 	} elseif ( array_key_exists( $key, $_REQUEST ) ) {
 		$value = $_REQUEST[ $key ];
 	} else {
 		$value = '';
 	}
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing
 
 	if ( is_string( $value ) ) {
 		$value = wp_unslash( $value );
@@ -1051,7 +1076,7 @@ function tml_get_request_value( $key, $type = 'any' ) {
 function tml_is_wp_login() {
 	global $pagenow;
 
-	return ( 'wp-login.php' == $pagenow );
+	return ( 'wp-login.php' === $pagenow );
 }
 
 /**
@@ -1136,7 +1161,8 @@ function tml_send_ajax_error( $data = null ) {
  * @return string The validated URL.
  */
 function tml_validate_redirect( $url ) {
-	return wp_validate_redirect( wp_sanitize_redirect( $url ),
+	return wp_validate_redirect(
+		wp_sanitize_redirect( $url ),
 		/** This filter is documented in wp-includes/pluggable.php */
 		apply_filters( 'wp_safe_redirect_fallback', admin_url(), 302 )
 	);
@@ -1151,7 +1177,7 @@ function tml_validate_redirect( $url ) {
  * @param array  $array    The array to be mapped.
  * @return array The resulting array.
  */
-function tml_array_map_recursive( $callback, $array ) {
+function tml_array_map_recursive( $callback, $array ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.arrayFound -- public API parameter name, renaming risks breaking PHP 8 named-argument callers.
 	foreach ( $array as $key => $value ) {
 		if ( is_array( $value ) ) {
 			$array[ $key ] = tml_array_map_recursive( $callback, $value );

--- a/src/includes/hooks.php
+++ b/src/includes/hooks.php
@@ -13,10 +13,10 @@
 
 // Actions and Forms
 add_action( 'init', 'tml_register_default_actions', 0 );
-add_action( 'init', 'tml_register_default_forms',   0 );
+add_action( 'init', 'tml_register_default_forms', 0 );
 
 // Rewrite
-add_action( 'init', 'tml_add_rewrite_tags'  );
+add_action( 'init', 'tml_add_rewrite_tags' );
 add_action( 'init', 'tml_add_rewrite_rules' );
 
 // Widgets
@@ -32,21 +32,21 @@ add_action( 'parse_query', 'tml_parse_query' );
 add_action( 'wp', 'tml_remove_default_actions_and_filters' );
 
 // Template
-add_action( 'template_redirect',  'tml_action_handler',   0 );
-add_action( 'wp_enqueue_scripts', 'tml_enqueue_styles',  10 );
+add_action( 'template_redirect', 'tml_action_handler', 0 );
+add_action( 'wp_enqueue_scripts', 'tml_enqueue_styles', 10 );
 add_action( 'wp_enqueue_scripts', 'tml_enqueue_scripts', 10 );
-add_action( 'wp_head',            'tml_do_login_head',   10 );
-add_action( 'wp_footer',          'tml_do_login_footer', 10 );
+add_action( 'wp_head', 'tml_do_login_head', 10 );
+add_action( 'wp_footer', 'tml_do_login_footer', 10 );
 
 // Registration
-add_action( 'pre_user_login',    'tml_set_user_login'        );
+add_action( 'pre_user_login', 'tml_set_user_login' );
 add_action( 'register_new_user', 'tml_set_new_user_password' );
-add_action( 'register_new_user', 'tml_handle_auto_login'     );
+add_action( 'register_new_user', 'tml_handle_auto_login' );
 
-add_action( 'register_new_user',      'tml_send_new_user_notifications', 10, 1 );
+add_action( 'register_new_user', 'tml_send_new_user_notifications', 10, 1 );
 add_action( 'edit_user_created_user', 'tml_send_new_user_notifications', 10, 2 );
 
-remove_action( 'register_new_user',      'wp_send_new_user_notifications' );
+remove_action( 'register_new_user', 'wp_send_new_user_notifications' );
 remove_action( 'edit_user_created_user', 'wp_send_new_user_notifications' );
 
 // Activation
@@ -60,16 +60,16 @@ add_action( 'tml_deactivate', 'tml_flush_rewrite_rules' );
  */
 
 // Pages
-add_filter( 'the_posts',          'tml_the_posts',                 10, 2 );
-add_filter( 'page_template',      'tml_page_template',             10, 3 );
-add_filter( 'body_class',         'tml_body_class',                10, 2 );
+add_filter( 'the_posts', 'tml_the_posts', 10, 2 );
+add_filter( 'page_template', 'tml_page_template', 10, 3 );
+add_filter( 'body_class', 'tml_body_class', 10, 2 );
 add_filter( 'get_edit_post_link', 'tml_filter_get_edit_post_link', 10, 2 );
-add_filter( 'comments_array',     'tml_filter_comments_array',     10, 1 );
+add_filter( 'comments_array', 'tml_filter_comments_array', 10, 1 );
 
 // URLs
-add_filter( 'site_url',         'tml_filter_site_url',         10, 3 );
-add_filter( 'network_site_url', 'tml_filter_site_url',         10, 3 );
-add_filter( 'logout_url',       'tml_filter_logout_url',       10, 2 );
+add_filter( 'site_url', 'tml_filter_site_url', 10, 3 );
+add_filter( 'network_site_url', 'tml_filter_site_url', 10, 3 );
+add_filter( 'logout_url', 'tml_filter_logout_url', 10, 2 );
 add_filter( 'lostpassword_url', 'tml_filter_lostpassword_url', 10, 2 );
 
 // Authentication
@@ -91,12 +91,12 @@ add_filter( 'wp_new_user_notification_email', 'tml_add_password_notice_to_new_us
 
 // Customizer
 add_filter( 'customize_nav_menu_available_item_types', 'tml_filter_customize_nav_menu_available_item_types', 10, 1 );
-add_filter( 'customize_nav_menu_available_items',      'tml_filter_customize_nav_menu_available_items',      10, 4 );
+add_filter( 'customize_nav_menu_available_items', 'tml_filter_customize_nav_menu_available_items', 10, 4 );
 
 // Nav menus
 add_filter( 'wp_setup_nav_menu_item', 'tml_setup_nav_menu_item', 0, 1 );
-add_filter( 'nav_menu_css_class',     'tml_nav_menu_css_class', 10, 2 );
+add_filter( 'nav_menu_css_class', 'tml_nav_menu_css_class', 10, 2 );
 
 // Extensions
-add_filter( 'plugins_api',                           'tml_add_extension_data_to_plugins_api',       10, 3 );
+add_filter( 'plugins_api', 'tml_add_extension_data_to_plugins_api', 10, 3 );
 add_filter( 'pre_set_site_transient_update_plugins', 'tml_add_extension_data_to_plugins_transient', 10, 1 );

--- a/src/includes/ms-functions.php
+++ b/src/includes/ms-functions.php
@@ -99,7 +99,7 @@ function tml_ms_register_user_signup_form() {
 			array(
 				'type'        => 'text',
 				'label'       => __( 'Username:' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated "Username:" string (see wp-signup.php), not a TML-specific string.
-				'description' => __( '(Must be at least 4 characters, letters and numbers only.)', 'theme-my-login' ),
+				'description' => __( '(Must be at least 4 characters, lowercase letters and numbers only.)' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated string (see wp-signup.php), not a TML-specific string.
 				'value'       => '',
 				'id'          => 'user_name',
 				'attributes'  => array(
@@ -130,7 +130,7 @@ function tml_ms_register_user_signup_form() {
 		array(
 			'type'        => 'email',
 			'label'       => __( 'Email&nbsp;Address:' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated "Email&nbsp;Address:" string (see wp-signup.php), not a TML-specific string.
-			'description' => __( 'We send your registration email to this address. (Double-check your email address before continuing.)', 'theme-my-login' ),
+			'description' => __( 'Your registration email is sent to this address. (Double-check your email address before continuing.)' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated string (see wp-signup.php), not a TML-specific string.
 			'value'       => '',
 			'id'          => 'user_email',
 			'attributes'  => array(
@@ -265,7 +265,7 @@ function tml_ms_register_blog_signup_form() {
 		'submit',
 		array(
 			'type'     => 'submit',
-			'value'    => __( 'Signup', 'theme-my-login' ),
+			'value'    => __( 'Sign up' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated string (see wp-signup.php), not a TML-specific string.
 			'priority' => 30,
 		)
 	);
@@ -347,7 +347,7 @@ function tml_ms_add_blog_signup_form_fields( $form ) {
 			'blogname',
 			array(
 				'type'        => 'text',
-				'label'       => __( 'Site Name: ', 'theme-my-login' ),
+				'label'       => __( 'Site Name (subdirectory only):' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated string (see wp-signup.php), not a TML-specific string.
 				'value'       => '',
 				'id'          => 'blogname',
 				'attributes'  => array(
@@ -375,7 +375,7 @@ function tml_ms_add_blog_signup_form_fields( $form ) {
 			'blogname',
 			array(
 				'type'        => 'text',
-				'label'       => __( 'Site Domain:', 'theme-my-login' ),
+				'label'       => __( 'Site Domain (subdomain only):' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated string (see wp-signup.php), not a TML-specific string.
 				'value'       => '',
 				'id'          => 'blogname',
 				'attributes'  => array(
@@ -791,7 +791,7 @@ function tml_ms_filter_signup_shortcode( $content = '', $action = 'signup', $att
 						$content .= '<h2>' . sprintf( __( '%s is your new username' ), tml_is_email_login_type() ? $result['user_email'] : $result['user_name'] ) . '</h2>';
 						$content .= '<p>' . __( 'But, before you can start using your new username, <strong>you must activate it</strong>.' ) . '</p>';
 						/* translators: %s: The user email address. */
-						$content .= '<p>' . sprintf( __( 'Check your inbox at %s and click the link given.', 'theme-my-login' ), '<strong>' . $result['user_email'] . '</strong>' ) . '</p>';
+						$content .= '<p>' . sprintf( __( 'Check your inbox at %s and click on the given link.' ), '<strong>' . $result['user_email'] . '</strong>' ) . '</p>';
 						$content .= '<p>' . __( 'If you do not activate your username within two days, you will have to sign up again.' ) . '</p>';
 					}
 				} else {
@@ -812,12 +812,12 @@ function tml_ms_filter_signup_shortcode( $content = '', $action = 'signup', $att
 						$content .= '<h2>' . sprintf( __( 'Congratulations! Your new site, %s, is almost ready.' ), "<a href='http://{$blog_result['domain']}{$blog_result['path']}'>{$blog_result['blog_title']}</a>" ) . '</h2>';
 						$content .= '<p>' . __( 'But, before you can start using your site, <strong>you must activate it</strong>.' ) . '</p>';
 						/* translators: %s: The user email address. */
-						$content .= '<p>' . sprintf( __( 'Check your inbox at %s and click the link given.', 'theme-my-login' ), '<strong>' . $user_result['user_email'] . '</strong>' ) . '</p>';
+						$content .= '<p>' . sprintf( __( 'Check your inbox at %s and click on the given link.' ), '<strong>' . $user_result['user_email'] . '</strong>' ) . '</p>';
 						$content .= '<p>' . __( 'If you do not activate your site within two days, you will have to sign up again.' ) . '</p>';
 						$content .= '<h2>' . __( 'Still waiting for your email?' ) . '</h2>';
 						/* translators: %s: The user email address. */
 						$content .= '<p>' .
-								__( 'If you haven&#8217;t received your email yet, there are a number of things you can do:', 'theme-my-login' ) . '
+								__( 'If you have not received your email yet, there are a number of things you can do:' ) . '
 								<ul id="noemail-tips">
 									<li><p><strong>' . __( 'Wait a little longer. Sometimes delivery of email can be delayed by processes outside of our control.' ) . '</strong></p></li>
 									<li><p>' . __( 'Check the junk or spam folder of your email client. Sometime emails wind up there by mistake.' ) . '</p></li>
@@ -1048,9 +1048,9 @@ function tml_ms_get_another_blog_signup_form( $blogname = '', $blog_title = '', 
 		}
 		$before .= '</ul>';
 	}
-	// phpcs:enable WordPress.WP.I18n.MissingArgDomain, WordPress.WP.I18n.MissingTranslatorsComment
 
-	$before .= '<p>' . __( 'If you&#8217;re not going to use a great site domain, leave it for a new user. Now have at it!', 'theme-my-login' ) . '</p>';
+	$before .= '<p>' . __( 'If you are not going to use a great site domain, leave it for a new user. Now have at it!' ) . '</p>';
+	// phpcs:enable WordPress.WP.I18n.MissingArgDomain, WordPress.WP.I18n.MissingTranslatorsComment
 
 	$form = tml_get_form( 'another_blog_signup' );
 

--- a/src/includes/ms-functions.php
+++ b/src/includes/ms-functions.php
@@ -13,25 +13,31 @@
  * @since 7.0
  */
 function tml_ms_register_default_actions() {
-	tml_register_action( 'signup', array(
-		'title'             => '',
-		'slug'              => 'signup',
-		'callback'          => 'tml_ms_signup_handler',
-		'network'           => true,
-		'show_on_forms'     => false,
-		'show_in_widget'    => false,
-		'show_in_nav_menus' => false,
-	) );
+	tml_register_action(
+		'signup',
+		array(
+			'title'             => '',
+			'slug'              => 'signup',
+			'callback'          => 'tml_ms_signup_handler',
+			'network'           => true,
+			'show_on_forms'     => false,
+			'show_in_widget'    => false,
+			'show_in_nav_menus' => false,
+		)
+	);
 
-	tml_register_action( 'activate', array(
-		'title'             => '',
-		'slug'              => 'activate',
-		'callback'          => 'tml_ms_activation_handler',
-		'network'           => true,
-		'show_on_forms'     => false,
-		'show_in_widget'    => false,
-		'show_in_nav_menus' => false,
-	) );
+	tml_register_action(
+		'activate',
+		array(
+			'title'             => '',
+			'slug'              => 'activate',
+			'callback'          => 'tml_ms_activation_handler',
+			'network'           => true,
+			'show_on_forms'     => false,
+			'show_in_widget'    => false,
+			'show_in_nav_menus' => false,
+		)
+	);
 }
 
 /**
@@ -53,103 +59,148 @@ function tml_ms_register_default_forms() {
  */
 function tml_ms_register_user_signup_form() {
 
-	tml_register_form( 'user_signup', array(
-		'action'      => tml_get_action_url( 'signup' ),
-		'attributes'  => array(
-			'id'         => 'setupform',
-			'novalidate' => 'novalidate',
-		),
-		'render_args' => array(
-			'show_links' => false,
-		),
-	) );
+	tml_register_form(
+		'user_signup',
+		array(
+			'action'      => tml_get_action_url( 'signup' ),
+			'attributes'  => array(
+				'id'         => 'setupform',
+				'novalidate' => 'novalidate',
+			),
+			'render_args' => array(
+				'show_links' => false,
+			),
+		)
+	);
 
-	tml_add_form_field( 'user_signup', 'stage', array(
-		'type'     => 'hidden',
-		'value'    => 'validate-user-signup',
-		'priority' => 5,
-	) );
+	tml_add_form_field(
+		'user_signup',
+		'stage',
+		array(
+			'type'     => 'hidden',
+			'value'    => 'validate-user-signup',
+			'priority' => 5,
+		)
+	);
 
-	tml_add_form_field( 'user_signup', 'signup_hidden_fields', array(
-		'type'        => 'action',
-		'render_args' => array( 'validate-user' ),
-	) );
+	tml_add_form_field(
+		'user_signup',
+		'signup_hidden_fields',
+		array(
+			'type'        => 'action',
+			'render_args' => array( 'validate-user' ),
+		)
+	);
 
 	if ( tml_is_default_registration_type() ) {
-		tml_add_form_field( 'user_signup', 'user_name', array(
-			'type'        => 'text',
-			'label'       => __( 'Username:' ),
-			'description' => __( '(Must be at least 4 characters, letters and numbers only.)' ),
-			'value'       => '',
-			'id'          => 'user_name',
-			'attributes'  => array(
-				'autocapitalize' => 'none',
-				'autocorrect'    => 'off',
-				'maxlength'      => 60,
-			),
-			'priority'    => 10,
-		) );
+		tml_add_form_field(
+			'user_signup',
+			'user_name',
+			array(
+				'type'        => 'text',
+				'label'       => __( 'Username:' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated "Username:" string (see wp-signup.php), not a TML-specific string.
+				'description' => __( '(Must be at least 4 characters, letters and numbers only.)', 'theme-my-login' ),
+				'value'       => '',
+				'id'          => 'user_name',
+				'attributes'  => array(
+					'autocapitalize' => 'none',
+					'autocorrect'    => 'off',
+					'maxlength'      => 60,
+				),
+				'priority'    => 10,
+			)
+		);
 	} else {
-		tml_add_form_field( 'user_signup', 'user_name', array(
-			'type'     => 'hidden',
-			'label'    => '',
-			'value'    => 'user' . md5( microtime() ),
-			'id'       => 'user_name',
-			'priority' => 10,
-		) );
+		tml_add_form_field(
+			'user_signup',
+			'user_name',
+			array(
+				'type'     => 'hidden',
+				'label'    => '',
+				'value'    => 'user' . md5( microtime() ),
+				'id'       => 'user_name',
+				'priority' => 10,
+			)
+		);
 	}
 
-	tml_add_form_field( 'user_signup', 'user_email', array(
-		'type'        => 'email',
-		'label'       => __( 'Email&nbsp;Address:' ),
-		'description' => __( 'We send your registration email to this address. (Double-check your email address before continuing.)' ),
-		'value'       => '',
-		'id'          => 'user_email',
-		'attributes'  => array(
-			'maxlength' => 200,
-		),
-		'priority'    => 15,
-	) );
+	tml_add_form_field(
+		'user_signup',
+		'user_email',
+		array(
+			'type'        => 'email',
+			'label'       => __( 'Email&nbsp;Address:' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated "Email&nbsp;Address:" string (see wp-signup.php), not a TML-specific string.
+			'description' => __( 'We send your registration email to this address. (Double-check your email address before continuing.)', 'theme-my-login' ),
+			'value'       => '',
+			'id'          => 'user_email',
+			'attributes'  => array(
+				'maxlength' => 200,
+			),
+			'priority'    => 15,
+		)
+	);
 
-	tml_add_form_field( 'user_signup', 'signup_extra_fields', array(
-		'type'        => 'action',
-		'render_args' => array( tml_get_errors() ),
-	) );
+	tml_add_form_field(
+		'user_signup',
+		'signup_extra_fields',
+		array(
+			'type'        => 'action',
+			'render_args' => array( tml_get_errors() ),
+		)
+	);
 
 	$active_signup = tml_ms_signup_get_active_signup();
 
-	if ( 'blog' == $active_signup ) {
-		tml_add_form_field( 'user_signup', 'signup_for', array(
-			'type'     => 'hidden',
-			'value'    => 'blog',
-			'id'       => 'signupblog',
-			'priority' => 20,
-		) );
-	} elseif ( 'user' == $active_signup ) {
-		tml_add_form_field( 'user_signup', 'signup_for', array(
-			'type'     => 'hidden',
-			'value'    => 'user',
-			'id'       => 'signupuser',
-			'priority' => 20,
-		) );
+	if ( 'blog' === $active_signup ) {
+		tml_add_form_field(
+			'user_signup',
+			'signup_for',
+			array(
+				'type'     => 'hidden',
+				'value'    => 'blog',
+				'id'       => 'signupblog',
+				'priority' => 20,
+			)
+		);
+	} elseif ( 'user' === $active_signup ) {
+		tml_add_form_field(
+			'user_signup',
+			'signup_for',
+			array(
+				'type'     => 'hidden',
+				'value'    => 'user',
+				'id'       => 'signupuser',
+				'priority' => 20,
+			)
+		);
 	} else {
-		tml_add_form_field( 'user_signup', 'signup_for', array(
-			'type'     => 'radio-group',
-			'options'  => array(
-				'blog' => __( 'Gimme a site!' ),
-				'user' => __( 'Just a username, please.' ),
-			),
-			'value'    => isset( $_POST['signup_for'] ) ? $_POST['signup_for'] : 'blog',
-			'priority' => 20,
-		) );
+		tml_add_form_field(
+			'user_signup',
+			'signup_for',
+			array(
+				'type'     => 'radio-group',
+				// phpcs:disable WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated wp-signup.php strings verbatim, not TML-specific strings.
+				'options'  => array(
+					'blog' => __( 'Gimme a site!' ),
+					'user' => __( 'Just a username, please.' ),
+				),
+				// phpcs:enable WordPress.WP.I18n.MissingArgDomain
+				'value'    => isset( $_POST['signup_for'] ) ? $_POST['signup_for'] : 'blog', // phpcs:ignore WordPress.Security.NonceVerification.Missing -- read-only: pre-fills the field's default selection, not processed/acted on.
+				'priority' => 20,
+			)
+		);
 	}
 
-	tml_add_form_field( 'user_signup', 'submit', array(
-		'type'     => 'submit',
-		'name'     => 'submit',
-		'value'    => __( 'Next' ),
-		'priority' => 25,
-	) );
+	tml_add_form_field(
+		'user_signup',
+		'submit',
+		array(
+			'type'     => 'submit',
+			'name'     => 'submit',
+			'value'    => __( 'Next' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated "Next" string (see wp-signup.php), not a TML-specific string.
+			'priority' => 25,
+		)
+	);
 }
 
 /**
@@ -159,42 +210,65 @@ function tml_ms_register_user_signup_form() {
  */
 function tml_ms_register_blog_signup_form() {
 
-	tml_register_form( 'blog_signup', array(
-		'action'      => tml_get_action_url( 'signup' ),
-		'attributes'  => array(
-			'id' => 'setupform',
-		),
-		'render_args' => array(
-			'show_links' => false,
+	tml_register_form(
+		'blog_signup',
+		array(
+			'action'      => tml_get_action_url( 'signup' ),
+			'attributes'  => array(
+				'id' => 'setupform',
+			),
+			'render_args' => array(
+				'show_links' => false,
+			),
 		)
-	) );
+	);
 
-	tml_add_form_field( 'blog_signup', 'stage', array(
-		'type'     => 'hidden',
-		'value'    => 'validate-blog-signup',
-		'priority' => 5,
-	) );
-	tml_add_form_field( 'blog_signup', 'user_name', array(
-		'type'     => 'hidden',
-		'priority' => 5,
-	) );
-	tml_add_form_field( 'blog_signup', 'user_email', array(
-		'type'     => 'hidden',
-		'priority' => 5,
-	) );
+	tml_add_form_field(
+		'blog_signup',
+		'stage',
+		array(
+			'type'     => 'hidden',
+			'value'    => 'validate-blog-signup',
+			'priority' => 5,
+		)
+	);
+	tml_add_form_field(
+		'blog_signup',
+		'user_name',
+		array(
+			'type'     => 'hidden',
+			'priority' => 5,
+		)
+	);
+	tml_add_form_field(
+		'blog_signup',
+		'user_email',
+		array(
+			'type'     => 'hidden',
+			'priority' => 5,
+		)
+	);
 
-	tml_add_form_field( 'blog_signup', 'signup_hidden_fields', array(
-		'type'        => 'action',
-		'render_args' => array( 'validate-site' ),
-	) );
+	tml_add_form_field(
+		'blog_signup',
+		'signup_hidden_fields',
+		array(
+			'type'        => 'action',
+			'render_args' => array( 'validate-site' ),
+		)
+	);
 
 	tml_ms_add_blog_signup_form_fields( 'blog_signup' );
 
-	tml_add_form_field( 'blog_signup', 'submit', array(
-		'type'     => 'submit',
-		'value'    => __( 'Signup' ),
-		'priority' => 30,
-	) );
+	tml_add_form_field(
+		'blog_signup',
+		'submit',
+		array(
+			'type'     => 'submit',
+			'value'    => __( 'Signup', 'theme-my-login' ),
+			'priority' => 30,
+		)
+	);
 }
 
 /**
@@ -204,34 +278,49 @@ function tml_ms_register_blog_signup_form() {
  */
 function tml_ms_register_another_blog_signup_form() {
 
-	tml_register_form( 'another_blog_signup', array(
-		'action'      => tml_get_action_url( 'signup' ),
-		'attributes'  => array(
-			'id' => 'setupform',
-		),
-		'render_args' => array(
-			'show_links' => false,
+	tml_register_form(
+		'another_blog_signup',
+		array(
+			'action'      => tml_get_action_url( 'signup' ),
+			'attributes'  => array(
+				'id' => 'setupform',
+			),
+			'render_args' => array(
+				'show_links' => false,
+			),
 		)
-	) );
+	);
 
-	tml_add_form_field( 'another_blog_signup', 'stage', array(
-		'type'     => 'hidden',
-		'value'    => 'gimmeanotherblog',
-		'priority' => 5,
-	) );
+	tml_add_form_field(
+		'another_blog_signup',
+		'stage',
+		array(
+			'type'     => 'hidden',
+			'value'    => 'gimmeanotherblog',
+			'priority' => 5,
+		)
+	);
 
-	tml_add_form_field( 'another_blog_signup', 'signup_hidden_fields', array(
-		'type'        => 'action',
-		'render_args' => array( 'create-another-site' ),
-	) );
+	tml_add_form_field(
+		'another_blog_signup',
+		'signup_hidden_fields',
+		array(
+			'type'        => 'action',
+			'render_args' => array( 'create-another-site' ),
+		)
+	);
 
 	tml_ms_add_blog_signup_form_fields( 'another_blog_signup' );
 
-	tml_add_form_field( 'another_blog_signup', 'submit', array(
-		'type'     => 'submit',
-		'value'    => __( 'Create Site' ),
-		'priority' => 30,
-	) );
+	tml_add_form_field(
+		'another_blog_signup',
+		'submit',
+		array(
+			'type'     => 'submit',
+			'value'    => __( 'Create Site' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated "Create Site" string (see wp-signup.php), not a TML-specific string.
+			'priority' => 30,
+		)
+	);
 }
 
 /**
@@ -244,82 +333,114 @@ function tml_ms_register_another_blog_signup_form() {
 function tml_ms_add_blog_signup_form_fields( $form ) {
 	$current_network = get_network();
 
+	// phpcs:disable WordPress.WP.I18n.MissingArgDomain, WordPress.WP.I18n.MissingTranslatorsComment -- these messages intentionally reuse WP core's translated wp-signup.php strings verbatim, not TML-specific strings; no translators comments since they never enter TML's own .pot.
 	if ( ! is_subdomain_install() ) {
 		$control_after = '<br />';
 		if ( ! is_user_logged_in() ) {
 			$control_after .= '<p>(<strong>' . sprintf( __( 'Your address will be %s.' ), $current_network->domain . $current_network->path . __( 'sitename' ) ) . '</strong>) ';
 			$control_after .= __( 'Must be at least 4 characters, letters and numbers only. It cannot be changed, so choose carefully!' ) . '</p>';
 		}
+		// phpcs:enable WordPress.WP.I18n.MissingArgDomain, WordPress.WP.I18n.MissingTranslatorsComment
 
-		tml_add_form_field( $form, 'blogname', array(
-			'type'        => 'text',
-			'label'       => __( 'Site Name: '),
-			'value'       => '',
-			'id'          => 'blogname',
-			'attributes'  => array(
-				'maxlength' => 60,
-			),
-			'priority'    => 10,
-			'render_args' => array(
-				'control_before' => '<span class="prefix_address">' . $current_network->domain . $current_network->path . '</span>',
-				'control_after'  => $control_after,
-			),
-		) );
+		tml_add_form_field(
+			$form,
+			'blogname',
+			array(
+				'type'        => 'text',
+				'label'       => __( 'Site Name: ', 'theme-my-login' ),
+				'value'       => '',
+				'id'          => 'blogname',
+				'attributes'  => array(
+					'maxlength' => 60,
+				),
+				'priority'    => 10,
+				'render_args' => array(
+					'control_before' => '<span class="prefix_address">' . $current_network->domain . $current_network->path . '</span>',
+					'control_after'  => $control_after,
+				),
+			)
+		);
 	} else {
-		$control_after = '<span class="suffix_address">.' . ( $site_domain = preg_replace( '|^www\.|', '', $current_network->domain ) ) . '</span><br />';
+		// phpcs:disable WordPress.WP.I18n.MissingArgDomain, WordPress.WP.I18n.MissingTranslatorsComment -- these messages intentionally reuse WP core's translated wp-signup.php strings verbatim, not TML-specific strings; no translators comments since they never enter TML's own .pot.
+		$site_domain   = preg_replace( '|^www\.|', '', $current_network->domain );
+		$control_after = '<span class="suffix_address">.' . $site_domain . '</span><br />';
 		if ( ! is_user_logged_in() ) {
 			$control_after .= '<p>(<strong>' . sprintf( __( 'Your address will be %s.' ), __( 'domain' ) . '.' . $site_domain . $current_network->path ) . '</strong>) ';
 			$control_after .= __( 'Must be at least 4 characters, letters and numbers only. It cannot be changed, so choose carefully!' ) . '</p>';
 		}
+		// phpcs:enable WordPress.WP.I18n.MissingArgDomain, WordPress.WP.I18n.MissingTranslatorsComment
 
-		tml_add_form_field( $form, 'blogname', array(
-			'type'        => 'text',
-			'label'       => __( 'Site Domain:' ),
-			'value'       => '',
-			'id'          => 'blogname',
-			'attributes'  => array(
-				'maxlength' => 60,
+		tml_add_form_field(
+			$form,
+			'blogname',
+			array(
+				'type'        => 'text',
+				'label'       => __( 'Site Domain:', 'theme-my-login' ),
+				'value'       => '',
+				'id'          => 'blogname',
+				'attributes'  => array(
+					'maxlength' => 60,
+				),
+				'priority'    => 10,
+				'render_args' => array(
+					'control_after' => $control_after,
+				),
+			)
+		);
+	}
+
+	tml_add_form_field(
+		$form,
+		'blog_title',
+		array(
+			'type'     => 'text',
+			'label'    => __( 'Site Title:' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reusing WP core's translated "Site Title:" string (see wp-signup.php), not a TML-specific string.
+			'id'       => 'blog_title',
+			'priority' => 15,
+		)
+	);
+
+	$language_field = tml_ms_render_blog_signup_language_field();
+	if ( $language_field ) {
+		tml_add_form_field(
+			$form,
+			'site_language',
+			array(
+				'type'     => 'custom',
+				'content'  => $language_field,
+				'priority' => 20,
+			)
+		);
+	}
+
+	tml_add_form_field(
+		$form,
+		'blog_public',
+		array(
+			'type'        => 'radio-group',
+			// phpcs:disable WordPress.WP.I18n.MissingArgDomain -- these labels intentionally reuse WP core's translated wp-signup.php strings verbatim, not TML-specific strings.
+			'label'       => __( 'Privacy:' ),
+			'value'       => isset( $_POST['blog_public'] ) && '0' === $_POST['blog_public'] ? 0 : 1, // phpcs:ignore WordPress.Security.NonceVerification.Missing -- read-only: pre-fills the field's default selection, not processed/acted on.
+			'options'     => array(
+				'1' => __( 'Yes' ),
+				'0' => __( 'No' ),
 			),
-			'priority'    => 10,
+			'priority'    => 25,
 			'render_args' => array(
-				'control_after' => $control_after,
+				'control_before' => __( 'Allow search engines to index this site.' ) . '<br style="clear:both" />',
 			),
-		) );
-	}
+			// phpcs:enable WordPress.WP.I18n.MissingArgDomain
+		)
+	);
 
-	tml_add_form_field( $form, 'blog_title', array(
-		'type'     => 'text',
-		'label'    => __( 'Site Title:' ),
-		'id'       => 'blog_title',
-		'priority' => 15,
-	) );
-
-	if ( $language_field = tml_ms_render_blog_signup_language_field() ) {
-		tml_add_form_field( $form, 'site_language', array(
-			'type'     => 'custom',
-			'content'  => $language_field,
-			'priority' => 20,
-		) );
-	}
-
-	tml_add_form_field( $form, 'blog_public', array(
-		'type'        => 'radio-group',
-		'label'       => __( 'Privacy:' ),
-		'value'       => isset( $_POST['blog_public'] ) && 0 == $_POST['blog_public'] ? 0 : 1,
-		'options'     => array(
-			'1' => __( 'Yes' ),
-			'0' => __( 'No'  ),
-		),
-		'priority'    => 25,
-		'render_args' => array(
-			'control_before' => __( 'Allow search engines to index this site.' ) . '<br style="clear:both" />',
-		),
-	) );
-
-	tml_add_form_field( $form, 'signup_blogform', array(
-		'type'        => 'action',
-		'render_args' => array( tml_get_errors() ),
-	) );
+	tml_add_form_field(
+		$form,
+		'signup_blogform',
+		array(
+			'type'        => 'action',
+			'render_args' => array( tml_get_errors() ),
+		)
+	);
 }
 
 /**
@@ -329,66 +450,95 @@ function tml_ms_add_blog_signup_form_fields( $form ) {
  */
 function tml_ms_register_activation_form() {
 
-	tml_register_form( 'activate', array(
-		'action'      => tml_get_action_url( 'activate' ),
-		'attributes'  => array(
-			'id'         => 'activateform',
-			'novalidate' => 'novalidate',
-		),
-		'render_args' => array(
-			'show_links' => false,
-		),
-	) );
+	tml_register_form(
+		'activate',
+		array(
+			'action'      => tml_get_action_url( 'activate' ),
+			'attributes'  => array(
+				'id'         => 'activateform',
+				'novalidate' => 'novalidate',
+			),
+			'render_args' => array(
+				'show_links' => false,
+			),
+		)
+	);
 
 	$key = tml_get_request_value( 'key' );
 
-	tml_add_form_field( 'activate', 'key', array(
-		'type'     => tml_allow_user_passwords() && $key ? 'hidden' : 'text',
-		'label'    => tml_allow_user_passwords() && $key ? ''       : __( 'Activation Key:' ),
-		'value'    => $key,
-		'id'       => 'key',
-		'priority' => 5,
-	) );
+	// phpcs:disable WordPress.WP.I18n.MissingArgDomain -- these labels intentionally reuse WP core's translated wp-activate.php/wp-login.php/user-new.php strings verbatim, not TML-specific strings.
+	tml_add_form_field(
+		'activate',
+		'key',
+		array(
+			'type'     => tml_allow_user_passwords() && $key ? 'hidden' : 'text',
+			'label'    => tml_allow_user_passwords() && $key ? '' : __( 'Activation Key:' ),
+			'value'    => $key,
+			'id'       => 'key',
+			'priority' => 5,
+		)
+	);
 
 	if ( tml_allow_user_passwords() && $key ) {
-		tml_add_form_field( 'activate', 'user_pass1', array(
-			'type'       => 'password',
-			'label'      => __( 'Password' ),
-			'id'         => 'pass1',
-			'attributes' => array(
-				'autocomplete' => 'off',
-			),
-			'priority'   => 10,
-		) );
+		tml_add_form_field(
+			'activate',
+			'user_pass1',
+			array(
+				'type'       => 'password',
+				'label'      => __( 'Password' ),
+				'id'         => 'pass1',
+				'attributes' => array(
+					'autocomplete' => 'off',
+				),
+				'priority'   => 10,
+			)
+		);
 
-		tml_add_form_field( 'activate', 'user_pass2', array(
-			'type'       => 'password',
-			'label'      => __( 'Confirm Password' ),
-			'id'         => 'pass2',
-			'attributes' => array(
-				'autocomplete' => 'off',
-			),
-			'priority'   => 10,
-		) );
+		tml_add_form_field(
+			'activate',
+			'user_pass2',
+			array(
+				'type'       => 'password',
+				'label'      => __( 'Confirm Password' ),
+				'id'         => 'pass2',
+				'attributes' => array(
+					'autocomplete' => 'off',
+				),
+				'priority'   => 10,
+			)
+		);
 
-		tml_add_form_field( 'activate', 'indicator', array(
-			'type'     => 'custom',
-			'content'  => '<div id="pass-strength-result" class="hide-if-no-js" aria-live="polite">' . __( 'Strength indicator' ) . '</div>',
-			'priority' => 10,
-		) );
+		tml_add_form_field(
+			'activate',
+			'indicator',
+			array(
+				'type'     => 'custom',
+				'content'  => '<div id="pass-strength-result" class="hide-if-no-js" aria-live="polite">' . __( 'Strength indicator' ) . '</div>',
+				'priority' => 10,
+			)
+		);
 
-		tml_add_form_field( 'activate', 'indicator_hint', array(
-			'type'     => 'custom',
-			'content'  => '<p class="description indicator-hint">' . wp_get_password_hint() . '</p>',
-			'priority' => 10,
-		) );
+		tml_add_form_field(
+			'activate',
+			'indicator_hint',
+			array(
+				'type'     => 'custom',
+				'content'  => '<p class="description indicator-hint">' . wp_get_password_hint() . '</p>',
+				'priority' => 10,
+			)
+		);
 	}
 
-	tml_add_form_field( 'activate', 'submit', array(
-		'type'     => 'submit',
-		'value'    => __( 'Activate' ),
-		'priority' => 15,
-	) );
+	tml_add_form_field(
+		'activate',
+		'submit',
+		array(
+			'type'     => 'submit',
+			'value'    => __( 'Activate' ),
+			'priority' => 15,
+		)
+	);
+	// phpcs:enable WordPress.WP.I18n.MissingArgDomain
 }
 
 /**
@@ -397,14 +547,15 @@ function tml_ms_register_activation_form() {
  * @since 7.0
  */
 function tml_ms_signup_handler() {
+	// phpcs:disable WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended -- mirrors wp-signup.php's own signup-processing, which is a public unauthenticated form with no nonce.
 
-	if ( is_array( get_site_option( 'illegal_names' ) ) && isset( $_GET['new'] ) && in_array( $_GET['new'], get_site_option( 'illegal_names' ) ) ) {
-		wp_redirect( network_home_url() );
+	if ( is_array( get_site_option( 'illegal_names' ) ) && isset( $_GET['new'] ) && in_array( $_GET['new'], get_site_option( 'illegal_names' ), true ) ) {
+		wp_redirect( network_home_url() ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- target is always network_home_url(), not user-controlled; matches wp-signup.php's own use of plain wp_redirect() here.
 		exit;
 	}
 
 	if ( ! is_multisite() ) {
-		wp_redirect( wp_registration_url() );
+		wp_redirect( wp_registration_url() ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- target is always wp_registration_url(), not user-controlled; matches wp-signup.php's own use of plain wp_redirect() here.
 		exit;
 	}
 
@@ -417,7 +568,7 @@ function tml_ms_signup_handler() {
 		 * @param bool $redirect Whether to redirect or not. Default true.
 		 */
 		if ( apply_filters( 'tml_redirect_subsite_to_network_signup', true ) ) {
-			wp_redirect( network_site_url( 'wp-signup.php' ) );
+			wp_redirect( network_site_url( 'wp-signup.php' ) ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- target is always network_site_url( 'wp-signup.php' ), not user-controlled; matches wp-signup.php's own use of plain wp_redirect() here.
 			exit;
 		}
 	}
@@ -429,7 +580,10 @@ function tml_ms_signup_handler() {
 	$stage = isset( $_POST['stage'] ) ? $_POST['stage'] : 'default';
 	switch ( $stage ) {
 		case 'validate-user-signup':
-			if ( $active_signup == 'all' || $_POST['signup_for'] == 'blog' && $active_signup == 'blog' || $_POST['signup_for'] == 'user' && $active_signup == 'user' ) {
+			if ( 'all' === $active_signup
+				|| ( 'blog' === $_POST['signup_for'] && 'blog' === $active_signup )
+				|| ( 'user' === $_POST['signup_for'] && 'user' === $active_signup )
+			) {
 				$result     = wpmu_validate_user_signup( $_POST['user_name'], $_POST['user_email'] );
 				$user_name  = $result['user_name'];
 				$user_email = $result['user_email'];
@@ -442,7 +596,7 @@ function tml_ms_signup_handler() {
 					return;
 				}
 
-				if ( 'blog' == $_POST['signup_for'] ) {
+				if ( 'blog' === $_POST['signup_for'] ) {
 					tml_set_data( 'signup_form', 'blog' );
 					return;
 				}
@@ -453,7 +607,7 @@ function tml_ms_signup_handler() {
 			break;
 
 		case 'validate-blog-signup':
-			if ( $active_signup == 'all' || $active_signup == 'blog' ) {
+			if ( 'all' === $active_signup || 'blog' === $active_signup ) {
 				$user_result = wpmu_validate_user_signup( $_POST['user_name'], $_POST['user_email'] );
 				$user_name   = $user_result['user_name'];
 				$user_email  = $user_result['user_email'];
@@ -462,7 +616,7 @@ function tml_ms_signup_handler() {
 				tml_set_data( 'signup_user_result', $user_result );
 
 				if ( $user_errors->get_error_code() ) {
-					tml_set_data( 'signup_form'. 'user' );
+					tml_set_data( 'signup_form', 'user' );
 					return;
 				}
 
@@ -489,7 +643,7 @@ function tml_ms_signup_handler() {
 				// Handle the language setting for the new site.
 				if ( ! empty( $_POST['site_language'] ) ) {
 					$languages = tml_ms_signup_get_available_languages();
-					if ( in_array( $_POST['site_language'], $languages ) ) {
+					if ( in_array( $_POST['site_language'], $languages, true ) ) {
 						$language = wp_unslash( sanitize_text_field( $_POST['site_language'] ) );
 						if ( $language ) {
 							$signup_meta['WPLANG'] = $language;
@@ -536,7 +690,7 @@ function tml_ms_signup_handler() {
 
 				$languages = tml_ms_signup_get_available_languages();
 
-				if ( in_array( $_POST['site_language'], $languages ) ) {
+				if ( in_array( $_POST['site_language'], $languages, true ) ) {
 					$language = wp_unslash( sanitize_text_field( $_POST['site_language'] ) );
 
 					if ( $language ) {
@@ -561,6 +715,7 @@ function tml_ms_signup_handler() {
 			do_action( 'preprocess_signup_form' );
 			break;
 	}
+	// phpcs:enable WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended
 }
 
 /**
@@ -573,8 +728,8 @@ function tml_ms_signup_handler() {
  * @param array  $atts    The shortcode attributes.
  * @return string The signup content if $action is 'signup' or the original content otherwise.
  */
-function tml_ms_filter_signup_shortcode( $content = '', $action = 'signup', $atts = array() ) {
-	if ( 'signup' != $action ) {
+function tml_ms_filter_signup_shortcode( $content = '', $action = 'signup', $atts = array() ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- kept for API/documented-signature consistency with the other shortcode-filter callbacks in this file.
+	if ( 'signup' !== $action ) {
 		return $content;
 	}
 
@@ -582,6 +737,7 @@ function tml_ms_filter_signup_shortcode( $content = '', $action = 'signup', $att
 
 	$active_signup = tml_ms_signup_get_active_signup();
 
+	// phpcs:disable WordPress.WP.I18n.MissingArgDomain, WordPress.WP.I18n.MissingTranslatorsComment, WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended -- these messages intentionally reuse WP core's translated wp-signup.php strings verbatim, not TML-specific strings, and this whole block is read-only rendering of the current signup stage/fields mirroring wp-signup.php's own unauthenticated signup form output, which has no nonce. (A single combined disable is used instead of nesting separate ones per sniff, since nested phpcs:disable/enable pairs for different sniff codes have been observed to corrupt phpcs's suppression tracking for the rest of the file.)
 	if ( current_user_can( 'manage_network' ) ) {
 		$content .= '<div class="tml-messages">' . __( 'Greetings Network Administrator!' ) . ' ';
 		switch ( $active_signup ) {
@@ -610,9 +766,9 @@ function tml_ms_filter_signup_shortcode( $content = '', $action = 'signup', $att
 
 	$newblogname = isset( $_GET['new'] ) ? strtolower( preg_replace( '/^-|-$|[^-a-zA-Z0-9]/', '', $_GET['new'] ) ) : null;
 
-	if ( $active_signup == 'none' ) {
+	if ( 'none' === $active_signup ) {
 		$content .= __( 'Registration has been disabled.' );
-	} elseif ( $active_signup == 'blog' && ! is_user_logged_in() ) {
+	} elseif ( 'blog' === $active_signup && ! is_user_logged_in() ) {
 		$content .= sprintf(
 			__( 'You must first <a href="%s">log in</a>, and then you can create a new site.' ),
 			wp_login_url( network_site_url( 'wp-signup.php' ) )
@@ -621,17 +777,21 @@ function tml_ms_filter_signup_shortcode( $content = '', $action = 'signup', $att
 		$stage = isset( $_POST['stage'] ) ? $_POST['stage'] : 'default';
 		switch ( $stage ) {
 			case 'validate-user-signup':
-				if ( $active_signup == 'all' || $_POST['signup_for'] == 'blog' && $active_signup == 'blog' || $_POST['signup_for'] == 'user' && $active_signup == 'user' ) {
+				if ( 'all' === $active_signup
+					|| ( 'blog' === $_POST['signup_for'] && 'blog' === $active_signup )
+					|| ( 'user' === $_POST['signup_for'] && 'user' === $active_signup )
+				) {
 					$result = tml_get_data( 'signup_result' );
 					$form   = tml_get_data( 'signup_form' );
-					if ( 'user' == $form ) {
+					if ( 'user' === $form ) {
 						$content .= tml_ms_get_user_signup_form( $result['user_name'], $result['user_email'], $result['errors'] );
-					} elseif ( 'blog' == $form ) {
+					} elseif ( 'blog' === $form ) {
 						$content .= tml_ms_get_blog_signup_form( $result['user_name'], $result['user_email'] );
 					} else {
 						$content .= '<h2>' . sprintf( __( '%s is your new username' ), tml_is_email_login_type() ? $result['user_email'] : $result['user_name'] ) . '</h2>';
 						$content .= '<p>' . __( 'But, before you can start using your new username, <strong>you must activate it</strong>.' ) . '</p>';
-						$content .= '<p>' . sprintf( __( 'Check your inbox at %s and click the link given.' ), '<strong>' . $result['user_email'] . '</strong>' ) . '</p>';
+						/* translators: %s: The user email address. */
+						$content .= '<p>' . sprintf( __( 'Check your inbox at %s and click the link given.', 'theme-my-login' ), '<strong>' . $result['user_email'] . '</strong>' ) . '</p>';
 						$content .= '<p>' . __( 'If you do not activate your username within two days, you will have to sign up again.' ) . '</p>';
 					}
 				} else {
@@ -640,22 +800,24 @@ function tml_ms_filter_signup_shortcode( $content = '', $action = 'signup', $att
 				break;
 
 			case 'validate-blog-signup':
-				if ( $active_signup == 'all' || $active_signup == 'blog' ) {
+				if ( 'all' === $active_signup || 'blog' === $active_signup ) {
 					$user_result = tml_get_data( 'signup_user_result' );
 					$blog_result = tml_get_data( 'signup_result' );
 					$form        = tml_get_data( 'signup_form' );
-					if ( 'user' == $form ) {
+					if ( 'user' === $form ) {
 						$content .= tml_ms_get_user_signup_form( $user_result['user_name'], $user_result['user_email'], $user_result['errors'] );
-					} elseif ( 'blog' == $form ) {
+					} elseif ( 'blog' === $form ) {
 						$content .= tml_ms_get_blog_signup_form( $user_result['user_name'], $user_result['user_email'], $blog_result['blogname'], $blog_result['blog_title'], $blog_result['errors'] );
 					} else {
 						$content .= '<h2>' . sprintf( __( 'Congratulations! Your new site, %s, is almost ready.' ), "<a href='http://{$blog_result['domain']}{$blog_result['path']}'>{$blog_result['blog_title']}</a>" ) . '</h2>';
 						$content .= '<p>' . __( 'But, before you can start using your site, <strong>you must activate it</strong>.' ) . '</p>';
-						$content .= '<p>' . sprintf( __( 'Check your inbox at %s and click the link given.' ), '<strong>' . $user_result['user_email'] . '</strong>' ) . '</p>';
+						/* translators: %s: The user email address. */
+						$content .= '<p>' . sprintf( __( 'Check your inbox at %s and click the link given.', 'theme-my-login' ), '<strong>' . $user_result['user_email'] . '</strong>' ) . '</p>';
 						$content .= '<p>' . __( 'If you do not activate your site within two days, you will have to sign up again.' ) . '</p>';
 						$content .= '<h2>' . __( 'Still waiting for your email?' ) . '</h2>';
+						/* translators: %s: The user email address. */
 						$content .= '<p>' .
-								__( 'If you haven&#8217;t received your email yet, there are a number of things you can do:' ) . '
+								__( 'If you haven&#8217;t received your email yet, there are a number of things you can do:', 'theme-my-login' ) . '
 								<ul id="noemail-tips">
 									<li><p><strong>' . __( 'Wait a little longer. Sometimes delivery of email can be delayed by processes outside of our control.' ) . '</strong></p></li>
 									<li><p>' . __( 'Check the junk or spam folder of your email client. Sometime emails wind up there by mistake.' ) . '</p></li>
@@ -671,7 +833,7 @@ function tml_ms_filter_signup_shortcode( $content = '', $action = 'signup', $att
 			case 'gimmeanotherblog':
 				$result = tml_get_data( 'signup_result' );
 				$form   = tml_get_data( 'signup_form' );
-				if ( 'another_blog' == $form ) {
+				if ( 'another_blog' === $form ) {
 					$content .= tml_ms_get_another_blog_signup_form( $result['blogname'], $result['blog_title'], $result['errors'] );
 				} else {
 					$blog_id = tml_get_data( 'signup_blog_id' );
@@ -686,13 +848,14 @@ function tml_ms_filter_signup_shortcode( $content = '', $action = 'signup', $att
 							$login_url = 'http://' . $result['domain'] . $result['path'] . 'wp-login.php';
 						}
 
-						$site = sprintf( '<a href="%1$s">%2$s</a>',
+						$site = sprintf(
+							'<a href="%1$s">%2$s</a>',
 							esc_url( $home_url ),
 							$result['blog_title']
 						);
 
 						$content .= '<h2>' . sprintf( __( 'The site %s is yours.' ), $site ) . '</h2>';
-						$content .=  sprintf(
+						$content .= sprintf(
 							__( '%1$s is your new site. <a href="%2$s">Log in</a> as &#8220;%3$s&#8221; using your existing password.' ),
 							sprintf(
 								'<a href="%s">%s</a>',
@@ -712,11 +875,11 @@ function tml_ms_filter_signup_shortcode( $content = '', $action = 'signup', $att
 
 				do_action( 'preprocess_signup_form' );
 
-				if ( is_user_logged_in() && ( $active_signup == 'all' || $active_signup == 'blog' ) ) {
+				if ( is_user_logged_in() && ( 'all' === $active_signup || 'blog' === $active_signup ) ) {
 					$content .= tml_ms_get_another_blog_signup_form( $newblogname );
-				} elseif ( ! is_user_logged_in() && ( $active_signup == 'all' || $active_signup == 'user' ) ) {
+				} elseif ( ! is_user_logged_in() && ( 'all' === $active_signup || 'user' === $active_signup ) ) {
 					$content .= tml_ms_get_user_signup_form( $newblogname, $user_email );
-				} elseif ( ! is_user_logged_in() && ( $active_signup == 'blog' ) ) {
+				} elseif ( ! is_user_logged_in() && 'blog' === $active_signup ) {
 					$content .= __( 'Sorry, new registrations are not allowed at this time.' );
 				} else {
 					$content .= __( 'You are logged in already. No need to register again!' );
@@ -725,7 +888,7 @@ function tml_ms_filter_signup_shortcode( $content = '', $action = 'signup', $att
 				if ( $newblogname ) {
 					$newblog = get_blogaddress_by_name( $newblogname );
 
-					if ( $active_signup == 'blog' || $active_signup == 'all' ) {
+					if ( 'blog' === $active_signup || 'all' === $active_signup ) {
 						$content .= sprintf(
 							'<p><em>' . __( 'The site you were looking for, %s, does not exist, but you can create it now!' ) . '</em></p>',
 							'<strong>' . $newblog . '</strong>'
@@ -740,6 +903,7 @@ function tml_ms_filter_signup_shortcode( $content = '', $action = 'signup', $att
 				break;
 		}
 	}
+	// phpcs:enable WordPress.WP.I18n.MissingArgDomain, WordPress.WP.I18n.MissingTranslatorsComment, WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended
 
 	return $content;
 }
@@ -755,10 +919,12 @@ function tml_ms_filter_signup_shortcode( $content = '', $action = 'signup', $att
  */
 function tml_ms_get_user_signup_form( $user_name = '', $user_email = '', $errors = '' ) {
 	if ( ! is_wp_error( $errors ) ) {
-		$errors  = new WP_Error();
+		$errors = new WP_Error();
 	}
 
+	// phpcs:disable WordPress.Security.NonceVerification.Missing -- read-only: mirrors the field's pre-filled default, not processed/acted on.
 	$signup_for = isset( $_POST['signup_for'] ) ? esc_html( $_POST['signup_for'] ) : 'blog';
+	// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 	/** This filter is documented in wp-signup.php */
 	$filtered_results = apply_filters( 'signup_user_init', compact( 'user_name', 'user_email', 'errors' ) );
@@ -770,25 +936,27 @@ function tml_ms_get_user_signup_form( $user_name = '', $user_email = '', $errors
 
 	$fields = compact( 'user_name', 'user_email' );
 	foreach ( $fields as $field => $value ) {
-		if ( ! $field = $form->get_field( $field ) ) {
+		$field = $form->get_field( $field );
+		if ( ! $field ) {
 			continue;
 		}
 
-		if ( $error = $errors->get_error_message( $field->get_name() ) ) {
+		$error = $errors->get_error_message( $field->get_name() );
+		if ( $error ) {
 			$field->set_error( $error );
-		} else {
-			if ( null !== $value ) {
+		} elseif ( null !== $value ) {
 				$field->set_value( $value );
-			}
 		}
 	}
 
-	return $form->render( array(
-		'before' => '<h2>' . sprintf(
-			__( 'Get your own %s account in seconds' ),
-			get_network()->site_name
-		) . '</h2>',
-	) );
+	return $form->render(
+		array(
+			'before' => '<h2>' . sprintf(
+				__( 'Get your own %s account in seconds' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain, WordPress.WP.I18n.MissingTranslatorsComment -- reusing WP core's translated "Get your own %s account in seconds" string (see wp-signup.php), not a TML-specific string; no translators comment since it never enters TML's own .pot.
+				get_network()->site_name
+			) . '</h2>',
+		)
+	);
 }
 
 /**
@@ -805,7 +973,7 @@ function tml_ms_get_user_signup_form( $user_name = '', $user_email = '', $errors
  */
 function tml_ms_get_blog_signup_form( $user_name = '', $user_email = '', $blogname = '', $blog_title = '', $errors = '' ) {
 	if ( ! is_wp_error( $errors ) ) {
-		$errors  = new WP_Error();
+		$errors = new WP_Error();
 	}
 
 	/** This filter is documented in wp-signup.php */
@@ -824,16 +992,16 @@ function tml_ms_get_blog_signup_form( $user_name = '', $user_email = '', $blogna
 
 	$fields = compact( 'user_name', 'user_email', 'blogname', 'blog_title' );
 	foreach ( $fields as $field => $value ) {
-		if ( ! $field = $form->get_field( $field ) ) {
+		$field = $form->get_field( $field );
+		if ( ! $field ) {
 			continue;
 		}
 
-		if ( $error = $errors->get_error_message( $field->get_name() ) ) {
+		$error = $errors->get_error_message( $field->get_name() );
+		if ( $error ) {
 			$field->set_error( $error );
-		} else {
-			if ( null !== $value ) {
+		} elseif ( null !== $value ) {
 				$field->set_value( $value );
-			}
 		}
 	}
 
@@ -863,6 +1031,7 @@ function tml_ms_get_another_blog_signup_form( $blogname = '', $blog_title = '', 
 	$blog_title       = $filtered_results['blog_title'];
 	$errors           = $filtered_results['errors'];
 
+	// phpcs:disable WordPress.WP.I18n.MissingArgDomain, WordPress.WP.I18n.MissingTranslatorsComment -- these messages intentionally reuse WP core's translated wp-signup.php strings verbatim, not TML-specific strings; no translators comments since they never enter TML's own .pot.
 	$before = '<h2>' . sprintf(
 		__( 'Get <em>another</em> %s site in seconds' ),
 		get_network()->site_name
@@ -875,27 +1044,28 @@ function tml_ms_get_another_blog_signup_form( $blogname = '', $blog_title = '', 
 		$before .= '<p>' . __( 'Sites you are already a member of:' ) . '</p><ul>';
 		foreach ( $blogs as $blog ) {
 			$home_url = get_home_url( $blog->userblog_id );
-			$before .= '<li><a href="' . esc_url( $home_url ) . '">' . $home_url . '</a></li>';
+			$before  .= '<li><a href="' . esc_url( $home_url ) . '">' . $home_url . '</a></li>';
 		}
 		$before .= '</ul>';
 	}
+	// phpcs:enable WordPress.WP.I18n.MissingArgDomain, WordPress.WP.I18n.MissingTranslatorsComment
 
-	$before .= '<p>' . __( 'If you&#8217;re not going to use a great site domain, leave it for a new user. Now have at it!' ) . '</p>';
+	$before .= '<p>' . __( 'If you&#8217;re not going to use a great site domain, leave it for a new user. Now have at it!', 'theme-my-login' ) . '</p>';
 
 	$form = tml_get_form( 'another_blog_signup' );
 
 	$fields = compact( 'blogname', 'blog_title' );
 	foreach ( $fields as $field => $value ) {
-		if ( ! $field = $form->get_field( $field ) ) {
+		$field = $form->get_field( $field );
+		if ( ! $field ) {
 			continue;
 		}
 
-		if ( $error = $errors->get_error_message( $field->get_name() ) ) {
+		$error = $errors->get_error_message( $field->get_name() );
+		if ( $error ) {
 			$field->set_error( $error );
-		} else {
-			if ( null !== $value ) {
+		} elseif ( null !== $value ) {
 				$field->set_value( $value );
-			}
 		}
 	}
 
@@ -918,23 +1088,27 @@ function tml_ms_render_blog_signup_language_field() {
 
 		$lang = get_site_option( 'WPLANG' );
 
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- read-only: pre-fills the field's default selection, not processed/acted on.
 		if ( isset( $_POST['site_language'] ) ) {
 			$lang = $_POST['site_language'];
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 		// Use US English if the default isn't available.
-		if ( ! in_array( $lang, $languages ) ) {
+		if ( ! in_array( $lang, $languages, true ) ) {
 			$lang = '';
 		}
 
-		$markup .= wp_dropdown_languages( array(
-			'echo'                        => false,
-			'name'                        => 'site_language',
-			'id'                          => 'site-language',
-			'selected'                    => $lang,
-			'languages'                   => $languages,
-			'show_available_translations' => false,
-		) );
+		$markup .= wp_dropdown_languages(
+			array(
+				'echo'                        => false,
+				'name'                        => 'site_language',
+				'id'                          => 'site-language',
+				'selected'                    => $lang,
+				'languages'                   => $languages,
+				'show_available_translations' => false,
+			)
+		);
 	}
 
 	return $markup;
@@ -983,7 +1157,7 @@ function tml_ms_activation_handler() {
 	define( 'WP_INSTALLING', true );
 
 	if ( ! is_multisite() ) {
-		wp_redirect( wp_registration_url() );
+		wp_redirect( wp_registration_url() ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- target is always wp_registration_url(), not user-controlled; matches wp-activate.php's own use of plain wp_redirect() here.
 		exit;
 	}
 
@@ -991,6 +1165,7 @@ function tml_ms_activation_handler() {
 		$wp_object_cache->cache_enabled = false;
 	}
 
+	// phpcs:disable WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended -- mirrors wp-activate.php's own activation-key processing, which is a public unauthenticated request with no nonce (the key itself is the credential).
 	if ( ! empty( $_GET['key'] ) || ! empty( $_POST['key'] ) ) {
 		$key = ! empty( $_GET['key'] ) ? $_GET['key'] : $_POST['key'];
 
@@ -1029,6 +1204,7 @@ function tml_ms_activation_handler() {
 
 		tml_set_data( 'activation_result', $result );
 	}
+	// phpcs:enable WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended
 }
 
 /**
@@ -1041,26 +1217,30 @@ function tml_ms_activation_handler() {
  * @param array  $atts    The shortcode attributes.
  * @return string The signup content if $action is 'signup' or the original content otherwise.
  */
-function tml_ms_filter_activation_shortcode( $content = '', $action = 'signup', $atts = array() ) {
-	if ( 'activate' != $action ) {
+function tml_ms_filter_activation_shortcode( $content = '', $action = 'signup', $atts = array() ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- kept for API/documented-signature consistency with the other shortcode-filter callbacks in this file.
+	if ( 'activate' !== $action ) {
 		return $content;
 	}
 
 	$content = '';
 
+	// phpcs:disable WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended -- mirrors wp-activate.php's own activation-key processing, which is a public unauthenticated request with no nonce (the key itself is the credential).
+	// phpcs:disable WordPress.WP.I18n.MissingArgDomain, WordPress.WP.I18n.MissingTranslatorsComment -- these messages intentionally reuse WP core's translated wp-activate.php strings verbatim, not TML-specific strings; no translators comments since they never enter TML's own .pot.
 	if ( empty( $_GET['key'] ) && empty( $_POST['key'] ) ) {
-		$content .= tml_get_form( 'activate' )->render( array(
-			'before' => '<h2>' . __( 'Activation Key Required' ) . '</h2>',
-		) );
+		$content .= tml_get_form( 'activate' )->render(
+			array(
+				'before' => '<h2>' . __( 'Activation Key Required' ) . '</h2>',
+			)
+		);
 	} else {
 		$result = tml_get_data( 'activation_result' );
 		if ( is_wp_error( $result ) ) {
-			if ( 'already_active' == $result->get_error_code() || 'blog_taken' == $result->get_error_code() ) {
+			if ( 'already_active' === $result->get_error_code() || 'blog_taken' === $result->get_error_code() ) {
 				$signup = $result->get_error_data();
 
 				$content .= '<h2>' . __( 'Your account is now active!' ) . '</h2>';
 				$content .= '<p class="lead-in">';
-				if ( $signup->domain . $signup->path == '' ) {
+				if ( '' === $signup->domain . $signup->path ) {
 					$content .= sprintf(
 						__( 'Your account has been activated. You may now <a href="%1$s">log in</a> to the site using your chosen username of &#8220;%2$s&#8221;. Please check your email inbox at %3$s for your password and login instructions. If you do not receive an email, please check your junk or spam folder. If you still do not receive an email within an hour, you can <a href="%4$s">reset your password</a>.' ),
 						network_site_url( 'wp-login.php', 'login' ),
@@ -1085,9 +1265,11 @@ function tml_ms_filter_activation_shortcode( $content = '', $action = 'signup', 
 					$form->set_errors( $result );
 				}
 
-				$content .= $form->render( array(
-					'before' => '<h2>' . __( 'New Password' ) . '</h2>',
-				) );
+				$content .= $form->render(
+					array(
+						'before' => '<h2>' . __( 'New Password' ) . '</h2>',
+					)
+				);
 			} else {
 				$content .= '<h2>' . __( 'An error occurred during the activation' ) . '</h2>';
 				$content .= '<p>' . $result->get_error_message() . '</p>';
@@ -1103,7 +1285,7 @@ function tml_ms_filter_activation_shortcode( $content = '', $action = 'signup', 
 			$content .= '<p><span class="h3">' . __( 'Password:' ) . '</span> ' . ( tml_allow_user_passwords() ? '****' : $result['password'] ) . '</p>';
 			$content .= '</div>';
 
-			if ( $url && $url != network_home_url( '', 'http' ) ) {
+			if ( $url && network_home_url( '', 'http' ) !== $url ) {
 				switch_to_blog( (int) $result['blog_id'] );
 				$login_url = wp_login_url();
 				restore_current_blog();
@@ -1118,6 +1300,8 @@ function tml_ms_filter_activation_shortcode( $content = '', $action = 'signup', 
 			}
 		}
 	}
+	// phpcs:enable WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended
+	// phpcs:enable WordPress.WP.I18n.MissingArgDomain, WordPress.WP.I18n.MissingTranslatorsComment
 
 	return $content;
 }
@@ -1131,9 +1315,11 @@ function tml_ms_filter_activation_shortcode( $content = '', $action = 'signup', 
  * @return array The user data to insert.
  */
 function tml_ms_filter_pre_insert_user_data( $data = array() ) {
+	// phpcs:disable WordPress.Security.NonceVerification.Missing -- reads the just-submitted new-account password to hash it for storage; the registration form itself has no nonce, matching wp-signup.php's own registration flow.
 	if ( tml_allow_user_passwords() && ! empty( $_POST['user_pass1'] ) ) {
 		$data['user_pass'] = wp_hash_password( $_POST['user_pass1'] );
 	}
+	// phpcs:enable WordPress.Security.NonceVerification.Missing
 	return $data;
 }
 
@@ -1150,9 +1336,11 @@ function tml_ms_filter_pre_insert_user_data( $data = array() ) {
  */
 function tml_ms_filter_welcome_email( $message, $blog_id, $user_id, $password ) {
 	$user = get_userdata( $user_id );
+	// phpcs:disable WordPress.Security.NonceVerification.Missing -- reads the just-submitted new-account password to substitute it into the welcome email; the registration form itself has no nonce, matching wp-signup.php's own registration flow.
 	if ( tml_allow_user_passwords() && ! empty( $_POST['user_pass1'] ) ) {
 		$message = str_replace( $password, $_POST['user_pass1'], $message );
 	}
+	// phpcs:enable WordPress.Security.NonceVerification.Missing
 	if ( tml_is_email_login_type() ) {
 		$message = str_replace( $user->user_login, $user->user_email, $message );
 	}
@@ -1169,11 +1357,13 @@ function tml_ms_filter_welcome_email( $message, $blog_id, $user_id, $password ) 
  * @param string $password The user password.
  * @return string The welcome user message.
  */
-function tml_ms_filter_welcome_user_email( $message, $user_id, $password ) {
+function tml_ms_filter_welcome_user_email( $message, $user_id, $password ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- required by the 'update_welcome_user_email' filter's positional signature; the password is substituted via the 'PASSWORD' placeholder token instead.
 	$user = get_userdata( $user_id );
+	// phpcs:disable WordPress.Security.NonceVerification.Missing -- reads the just-submitted new-account password to substitute it into the welcome email; the registration form itself has no nonce, matching wp-signup.php's own registration flow.
 	if ( tml_allow_user_passwords() && ! empty( $_POST['user_pass1'] ) ) {
 		$message = str_replace( 'PASSWORD', $_POST['user_pass1'], $message );
 	}
+	// phpcs:enable WordPress.Security.NonceVerification.Missing
 	if ( tml_is_email_login_type() ) {
 		$message = str_replace( 'USERNAME', $user->user_email, $message );
 	}

--- a/src/includes/ms-hooks.php
+++ b/src/includes/ms-hooks.php
@@ -13,7 +13,7 @@
 
 // Actions and Forms
 add_action( 'init', 'tml_ms_register_default_actions', 0 );
-add_action( 'init', 'tml_ms_register_default_forms',   0 );
+add_action( 'init', 'tml_ms_register_default_forms', 0 );
 
 // Registration
 add_action( 'wpmu_activate_user', 'tml_handle_auto_login', 10, 2 );
@@ -24,13 +24,13 @@ add_action( 'wpmu_activate_blog', 'tml_handle_auto_login', 10, 2 );
  */
 
 // Shortcodes
-add_filter( 'tml_shortcode', 'tml_ms_filter_signup_shortcode',     10, 3 );
+add_filter( 'tml_shortcode', 'tml_ms_filter_signup_shortcode', 10, 3 );
 add_filter( 'tml_shortcode', 'tml_ms_filter_activation_shortcode', 10, 3 );
 
 // URLs
 add_filter( 'network_site_url', 'tml_filter_site_url', 10, 3 );
 
 // Passwords
-add_filter( 'wp_pre_insert_user_data',   'tml_ms_filter_pre_insert_user_data', 10, 1 );
-add_filter( 'update_welcome_email',      'tml_ms_filter_welcome_email',        10, 4 );
-add_filter( 'update_welcome_user_email', 'tml_ms_filter_welcome_user_email',   10, 3 );
+add_filter( 'wp_pre_insert_user_data', 'tml_ms_filter_pre_insert_user_data', 10, 1 );
+add_filter( 'update_welcome_email', 'tml_ms_filter_welcome_email', 10, 4 );
+add_filter( 'update_welcome_user_email', 'tml_ms_filter_welcome_user_email', 10, 3 );

--- a/src/includes/options.php
+++ b/src/includes/options.php
@@ -15,7 +15,8 @@
  * @return string|bool The installed TML version.
  */
 function tml_get_installed_version() {
-	if ( $options = get_option( 'theme_my_login' ) ) {
+	$options = get_option( 'theme_my_login' );
+	if ( $options ) {
 		if ( isset( $options['version'] ) ) {
 			return $options['version'];
 		}
@@ -45,7 +46,7 @@ function tml_use_permalinks() {
 	global $wp_rewrite;
 
 	if ( ! $wp_rewrite instanceof WP_Rewrite ) {
-		$wp_rewrite = new WP_Rewrite;
+		$wp_rewrite = new WP_Rewrite(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- lazily instantiates the same global WP core itself sets unconditionally at bootstrap (`$GLOBALS['wp_rewrite'] = new WP_Rewrite();` in wp-settings.php), for callers that may run before that point.
 	}
 
 	$use_permalinks = $wp_rewrite->using_permalinks() && get_site_option( 'tml_use_permalinks', true );
@@ -108,7 +109,7 @@ function tml_get_login_type() {
  * @return bool Whether using the default login type or not.
  */
 function tml_is_default_login_type() {
-	return 'default' == tml_get_login_type();
+	return 'default' === tml_get_login_type();
 }
 
 /**
@@ -119,7 +120,7 @@ function tml_is_default_login_type() {
  * @return bool Whether using the email login type or not.
  */
 function tml_is_email_login_type() {
-	return 'email' == tml_get_login_type();
+	return 'email' === tml_get_login_type();
 }
 
 /**
@@ -130,7 +131,7 @@ function tml_is_email_login_type() {
  * @return bool Whether using the username login type or not.
  */
 function tml_is_username_login_type() {
-	return 'username' == tml_get_login_type();
+	return 'username' === tml_get_login_type();
 }
 
 /**
@@ -161,7 +162,7 @@ function tml_get_registration_type() {
  * @return bool Whether using the default registration type or not.
  */
 function tml_is_default_registration_type() {
-	return 'default' == tml_get_registration_type();
+	return 'default' === tml_get_registration_type();
 }
 
 /**
@@ -172,7 +173,7 @@ function tml_is_default_registration_type() {
  * @return bool Whether using the email registration type or not.
  */
 function tml_is_email_registration_type() {
-	return 'email' == tml_get_registration_type();
+	return 'email' === tml_get_registration_type();
 }
 
 /**

--- a/src/includes/shortcodes.php
+++ b/src/includes/shortcodes.php
@@ -28,21 +28,30 @@ function tml_shortcode( $atts = array() ) {
 		$atts['action'] = $atts['default_action'];
 	}
 
-	$atts = shortcode_atts( array(
-		'action'      => '',
-		'show_links'  => null,
-		'redirect_to' => null,
-	), $atts, 'theme-my-login' );
+	$atts = shortcode_atts(
+		array(
+			'action'      => '',
+			'show_links'  => null,
+			'redirect_to' => null,
+		),
+		$atts,
+		'theme-my-login'
+	);
 
 	$content = '';
 
 	if ( empty( $atts['action'] ) ) {
 		$action = tml_is_action() ? tml_get_action() : tml_get_action( 'login' );
-	} elseif ( ! $action = tml_get_action( $atts['action'] ) ) {
-		return $content;
+	} else {
+		$action = tml_get_action( $atts['action'] );
+		if ( ! $action ) {
+			return $content;
+		}
 	}
 
-	if ( $form = tml_get_form( $action->get_name() ) ) {
+	$form = tml_get_form( $action->get_name() );
+
+	if ( $form ) {
 
 		$args = array();
 
@@ -51,7 +60,8 @@ function tml_shortcode( $atts = array() ) {
 		}
 
 		if ( null !== $atts['redirect_to'] ) {
-			if ( $redirect_to = $form->get_field( 'redirect_to' ) ) {
+			$redirect_to = $form->get_field( 'redirect_to' );
+			if ( $redirect_to ) {
 				$redirect_to->set_value( $atts['redirect_to'] );
 			}
 			unset( $redirect_to );
@@ -59,15 +69,18 @@ function tml_shortcode( $atts = array() ) {
 
 		$content = $form->render( $args );
 
-	} elseif ( 'confirmaction' == $action->get_name() && isset( $_GET['request_id'] ) ) {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- request_id/confirm_key are validated via wp_validate_user_request_key() in tml_confirmaction_handler() before this branch is ever reached.
+	} elseif ( 'confirmaction' === $action->get_name() && isset( $_GET['request_id'] ) ) {
 		$content = _wp_privacy_account_request_confirmed_message( $_GET['request_id'] );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
-	} elseif ( 'dashboard' == $action->get_name() ) {
+	} elseif ( 'dashboard' === $action->get_name() ) {
 		$content = '<div class="tml-dashboard">';
 
 		$content .= '<div class="tml-dashboard-avatar">' . get_avatar( get_current_user_id() ) . '</div>';
 
-		$content .= '<p class="tml-dashboard-greeting">' . sprintf( __( 'Howdy, %s' ), wp_get_current_user()->display_name ) . '</p>';
+		// translators: %s: Current user's display name.
+		$content .= '<p class="tml-dashboard-greeting">' . sprintf( __( 'Howdy, %s' ), wp_get_current_user()->display_name ) . '</p>'; // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- intentionally reusing WP core's translated "Howdy, %s" string (see wp-includes/admin-bar.php), not a TML-specific string.
 
 		/**
 		 * Filter the dashboard links.
@@ -76,20 +89,27 @@ function tml_shortcode( $atts = array() ) {
 		 *
 		 * @param array $links The dashboard links.
 		 */
-		$links = apply_filters( 'tml_dashboard_links', array_filter( array(
-			'site_admin' => current_user_can( 'edit_posts' ) ? array(
-				'title'  => __( 'Site Admin' ),
-				'url'    => admin_url(),
-			) : false,
-			'profile'    => array(
-				'title'  => __( 'Edit Profile' ),
-				'url'    => admin_url( 'profile.php' ),
-			),
-			'logout'     => array(
-				'title'  => __( 'Log Out' ),
-				'url'    => wp_logout_url(),
-			),
-		) ) );
+		// phpcs:disable WordPress.WP.I18n.MissingArgDomain -- these labels intentionally reuse WP core's translated strings ("Site Admin"/"Edit Profile"/"Log Out" all exist verbatim in wp-includes), not TML-specific strings.
+		$links = apply_filters(
+			'tml_dashboard_links',
+			array_filter(
+				array(
+					'site_admin' => current_user_can( 'edit_posts' ) ? array(
+						'title' => __( 'Site Admin' ),
+						'url'   => admin_url(),
+					) : false,
+					'profile'    => array(
+						'title' => __( 'Edit Profile' ),
+						'url'   => admin_url( 'profile.php' ),
+					),
+					'logout'     => array(
+						'title' => __( 'Log Out' ),
+						'url'   => wp_logout_url(),
+					),
+				)
+			)
+		);
+		// phpcs:enable WordPress.WP.I18n.MissingArgDomain
 
 		if ( ! empty( $links ) ) {
 			$content .= '<ul class="tml-dashboard-links">';

--- a/src/theme-my-login.php
+++ b/src/theme-my-login.php
@@ -38,7 +38,7 @@ define( 'THEME_MY_LOGIN_PATH', plugin_dir_path( __FILE__ ) );
  *
  * @since 7.0
  */
-define( 'THEME_MY_LOGIN_URL',  plugin_dir_url( __FILE__ ) );
+define( 'THEME_MY_LOGIN_URL', plugin_dir_url( __FILE__ ) );
 
 /**
  * Stores the URL to TML's extensions directory.


### PR DESCRIPTION
## Summary
- Add phpcs with the WordPress-Extra ruleset (plus PHPCompatibilityWP) via composer, and wire a lint job into CI.
- Bring the codebase to zero violations rather than leaving a partial backlog.
- Fix a handful of real bugs found along the way: stale wp-login.php cookie-help URLs, an undefined-variable reference in the license activation handler (`$license_data` → `$response`), a `true == $_GET['loggedout']` check that could never match, a blog-signup handler in `ms-functions.php` that passed a single concatenated string to `tml_set_data()` instead of two arguments (silently dropping an error-state write), and two `ms-functions.php` messages missing a text domain after their wording drifted from the `wp-signup.php` originals.

## Test plan
- [x] `phpcs` reports zero violations repo-wide.
- [x] Both PHPUnit suites (incl. multisite) pass.