### PR TITLE
chore: bump version to 7.1.15

### DIFF
--- a/src/readme.txt
+++ b/src/readme.txt
@@ -59,6 +59,17 @@ Report bugs, suggest ideas and participate in development at [GitHub](https://gi
 
 == Changelog ==
 
+= 7.1.15 =
+* Resync Multisite signup form strings with current WordPress core wording
+* Fix potential stored XSS in textarea form fields
+* Prevent a PHP 8.5 deprecation notice on wp-admin screens with no TML settings page
+* Escape settings field attributes to prevent stored XSS from unescaped option values
+* Sanitize Multisite network settings on save, matching single-site behavior
+* Verify nonce on extension license activate/deactivate requests to prevent CSRF
+* Fix extension icons not displaying due to unserialized API data
+* Reduce extension data added to the plugins update transient
+* Use a dedicated cache group when caching TML pages
+
 = 7.1.14 =
 * Ensure license nonce check only occurs on licenses page
 

--- a/src/theme-my-login.php
+++ b/src/theme-my-login.php
@@ -10,7 +10,7 @@
 Plugin Name: Theme My Login
 Plugin URI: https://thememylogin.com
 Description: Creates an alternate login, registration and password recovery experience within your theme.
-Version: 7.1.14
+Version: 7.1.15
 Author: Theme My Login
 Author URI: https://thememylogin.com
 License: GPLv2
@@ -24,7 +24,7 @@ Network: true
  *
  * @since 7.0
  */
-define( 'THEME_MY_LOGIN_VERSION', '7.1.14' );
+define( 'THEME_MY_LOGIN_VERSION', '7.1.15' );
 
 /**
  * Stores the path to TML.

--- a/theme-my-login.php
+++ b/theme-my-login.php
@@ -10,7 +10,7 @@
 Plugin Name: Theme My Login
 Plugin URI: https://thememylogin.com
 Description: Creates an alternate login, registration and password recovery experience within your theme.
-Version: 7.1.14
+Version: 7.1.15
 Author: Theme My Login
 Author URI: https://thememylogin.com
 License: GPLv2


### PR DESCRIPTION
## Summary
Version bump for the 7.1.15 release.

## Changelog
* Resync Multisite signup form strings with current WordPress core wording
* Fix potential stored XSS in textarea form fields
* Prevent a PHP 8.5 deprecation notice on wp-admin screens with no TML settings page
* Escape settings field attributes to prevent stored XSS from unescaped option values
* Sanitize Multisite network settings on save, matching single-site behavior
* Verify nonce on extension license activate/deactivate requests to prevent CSRF
* Fix extension icons not displaying due to unserialized API data
* Reduce extension data added to the plugins update transient
* Use a dedicated cache group when caching TML pages