### PR TITLE
fix: trim readme tags to 5 and add missing License field

### DIFF
--- a/src/readme.txt
+++ b/src/readme.txt
@@ -1,9 +1,11 @@
 === Theme My Login ===
 Contributors: thememylogin, jfarthing84
-Tags: login, register, password, branding, customize, widget, wp-login, wp-login.php
+Tags: login, register, password, branding, customize
 Requires at least: 5.4
 Tested up to: 6.8.2
 Stable tag: trunk
+License: GPLv2
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 The ultimate login branding solution! Theme My Login offers matchless customization of your WordPress user experience!
 


### PR DESCRIPTION
## Summary
Addresses the two warnings WordPress.org surfaces on plugin import:
* `Tags:` had 8 entries; WP.org silently ignores anything past 5 (`widget`, `wp-login`, `wp-login.php` were being dropped). Trimmed to the 5 already in effect.
* `License`/`License URI` were missing from `readme.txt`'s header (the plugin file itself declares them, but WP.org's readme parser needs its own copy). Added, matching the plugin file's existing `GPLv2` / `https://www.gnu.org/licenses/gpl-2.0.html`.