### PR TITLE
ci: lint every commit in a PR, not just the title

### DIFF
--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -1,0 +1,20 @@
+name: Lint commits
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+    branches: [ master ]
+
+jobs:
+  lint-commits:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: wagoid/commitlint-github-action@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 
 ## Commits and PR titles
 
-This repo uses [Conventional Commits](https://www.conventionalcommits.org/). PR titles are what matters most in practice — GitHub's default squash-merge uses the PR title as the resulting commit message on `master`, and that's what release automation will key off of.
+This repo uses [Conventional Commits](https://www.conventionalcommits.org/). PRs merge into `master` as real merge commits, not squashed, so every individual commit lands on `master` verbatim and is what release automation actually scans — the PR title is checked too (CI lints both), but it's the commits that count.
 
-Format: `type: subject` (lowercase after the colon, no trailing period).
+Format: `type: subject` (lowercase after the colon, no trailing period). This applies per-commit: squash together commits that are really one change split across saves before opening a PR (see the note on squashing below), but every commit that survives still needs its own correct type — CI lints each one individually, not just the PR title.
 
 Allowed types:
 
@@ -23,6 +23,25 @@ Allowed types:
 `feat`/`fix`/`perf` are the only types that ship in the plugin's changelog and trigger a version bump. The rest are invisible to plugin users by design.
 
 **Branch names should be prefixed with the same type**, e.g. `fix/nonce-check-on-license-page`, `feat/passwordless-login`, `chore/bump-phpunit`.
+
+### Squashing
+
+Before opening a PR, squash commits that are really incremental edits to the same change (fixup-style saves) into one. Leave commits separate when a PR genuinely contains multiple distinct logical changes — that's a per-PR judgment call, not something CI enforces or a repo-wide setting forces.
+
+### Major version bumps
+
+A major bump isn't manual — it's the same commit-driven mechanism as `feat`/`fix`, just marked as breaking. Either:
+
+- Add `!` after the type/scope: `feat!: drop support for PHP 7.4`
+- Or add a `BREAKING CHANGE:` footer to the commit body (any type):
+
+```
+fix!: remove deprecated tml_get_login_url() in favor of tml_get_action_url()
+
+BREAKING CHANGE: tml_get_login_url() has been removed; use tml_get_action_url( 'login' ) instead.
+```
+
+To force a specific version regardless of what the commits would otherwise compute (e.g. a deliberate version jump), add a `Release-As: X.Y.Z` footer to any commit.
 
 ### Keep subjects technical; use `Release-Note:` for user-facing wording
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+	extends: [ '@commitlint/config-conventional' ],
+	rules: {
+		'type-enum': [
+			2,
+			'always',
+			[ 'feat', 'fix', 'chore', 'ci', 'docs', 'build', 'perf', 'refactor', 'test' ],
+		],
+	},
+};


### PR DESCRIPTION
## Summary
- `lint-pr-title` only validates the PR title against Conventional Commits. Since PRs merge as real merge commits (not squashed), individual commit messages land on `master` verbatim and are never checked, so a badly-typed or unprefixed commit can slip through.
- Adds `wagoid/commitlint-github-action`, lints every commit in the PR's range using the same allowed-type list as `lint-pr-title` (`commitlint.config.js`).
- Documents the per-commit requirement and the existing squash-before-PR judgment call in `CONTRIBUTING.md`.

## Test plan
- [ ] Open a throwaway PR with one well-formed commit and one deliberately malformed commit (e.g. `oops fix the thing`), confirm the new check fails
- [ ] Fix the malformed commit, confirm the check passes