### PR TITLE
chore: bump wp-phpunit core and Tested up to 7.0.4

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1211,23 +1211,23 @@
         },
         {
             "name": "roots/wordpress-no-content",
-            "version": "7.0.2",
+            "version": "7.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress.git",
-                "reference": "7.0.2"
+                "reference": "7.0.4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.w.org/release/wordpress-7.0.2-no-content.zip",
-                "reference": "7.0.2",
-                "shasum": "52d2ca801cbfd75d1f2716d057095323b6ca424a"
+                "url": "https://downloads.w.org/release/wordpress-7.0.4-no-content.zip",
+                "reference": "7.0.4",
+                "shasum": "c43ba63174abfef77d00fbc6041db0d801869e09"
             },
             "require": {
                 "php": ">= 7.4"
             },
             "provide": {
-                "wordpress/core-implementation": "7.0.2"
+                "wordpress/core-implementation": "7.0.4"
             },
             "suggest": {
                 "ext-curl": "Performs remote request operations.",
@@ -1278,7 +1278,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-07-17T18:39:03+00:00"
+            "time": "2026-08-12T14:47:33+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -2,7 +2,7 @@
 Contributors: thememylogin, jfarthing84
 Tags: login, register, password, branding, customize
 Requires at least: 5.4
-Tested up to: 6.8.2
+Tested up to: 7.0.4
 Stable tag: trunk
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Summary
- `readme.txt`'s `Tested up to` was stuck at 6.8.2, 19 point releases behind current (6.8.3-6.8.8, all of 6.9.x, 7.0-7.0.4).
- Bumps `roots/wordpress-no-content` to 7.0.4 and reruns the PHPUnit suite against it.

## Test plan
- [x] `vendor/bin/phpunit`: 339 tests, 534 assertions, green