### PR TITLE
ci: fix changelog-draft bugs found on the pipeline's first real run

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,10 +32,11 @@ jobs:
       - name: Draft WordPress-style changelog onto the Release PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_PLEASE_PR: ${{ steps.release-please.outputs.pr }}
         run: |
           set -euo pipefail
 
-          branch=$(gh pr list --label "autorelease: pending" --base master --json headRefName --jq '.[0].headRefName')
+          branch=$(echo "$RELEASE_PLEASE_PR" | jq -r '.headBranchName // empty')
           if [ -z "$branch" ]; then
             echo "No pending release-please PR found; skipping changelog draft."
             exit 0

--- a/bin/draft-changelog.php
+++ b/bin/draft-changelog.php
@@ -29,7 +29,7 @@ $record_sep = "\x1e";
 $field_sep  = "\x1f";
 
 $log     = (string) shell_exec(
-	'git log ' . escapeshellarg( $range ) . " --pretty=format:%s{$field_sep}%b{$record_sep}"
+	'git log --no-merges ' . escapeshellarg( $range ) . " --pretty=format:%s{$field_sep}%b{$record_sep}"
 );
 $records = array_filter(
 	array_map( 'trim', explode( $record_sep, $log ) ),

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
     ".": {
       "release-type": "simple",
       "draft": true,
+      "skip-changelog": true,
       "extra-files": [
         {
           "type": "generic",


### PR DESCRIPTION
## Summary
Three real bugs surfaced by PR #222, the first Release PR the automated pipeline actually created:

- `git log` walks merge commits by default. PR #218 merged with a message that repeated its single child commit's `fix:` subject (GitHub's default for non-squash merges), so `bin/draft-changelog.php` counted it twice. Fixed with `--no-merges`.
- `release-please-action` generates its own `CHANGELOG.md` by default, separate from and redundant with the `readme.txt` entry `bin/draft-changelog.php` maintains. Disabled via `skip-changelog` in `release-please-config.json`.
- The changelog-draft step queried `gh pr list --label "autorelease: pending"` immediately after `release-please-action` created the PR, in the same job — raced GitHub's search API and came back empty, silently skipping the draft entirely. Now reads the PR's `headBranchName` straight from `release-please-action`'s own `pr` output instead of re-querying.

## Test plan
- [ ] Next release cycle produces a single changelog bullet per commit, no `CHANGELOG.md`, and the readme.txt draft actually lands on the Release PR