### PR TITLE
ci: push readme.txt to SVN trunk independently of a release

### DIFF
--- a/.github/workflows/deploy-readme.yml
+++ b/.github/workflows/deploy-readme.yml
@@ -1,0 +1,43 @@
+name: Deploy readme.txt
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'src/readme.txt'
+  workflow_dispatch: {}
+
+jobs:
+  deploy-readme:
+    runs-on: ubuntu-latest
+
+    env:
+      SLUG: theme-my-login
+      SVN_URL: https://plugins.svn.wordpress.org/theme-my-login
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install svn
+        run: sudo apt-get update -y && sudo apt-get install -y subversion
+
+      - name: Push readme.txt to WordPress.org trunk
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          SVN_DIR="${HOME}/svn-${SLUG}"
+
+          svn checkout --depth empty "${SVN_URL}/trunk" "${SVN_DIR}"
+          cp src/readme.txt "${SVN_DIR}/readme.txt"
+
+          cd "${SVN_DIR}"
+          svn add --force readme.txt -q
+
+          if svn status | grep -q '^[MA]'; then
+            svn commit -m "Update readme.txt" --no-auth-cache --non-interactive --username "${SVN_USERNAME}" --password "${SVN_PASSWORD}"
+          else
+            echo "readme.txt unchanged; nothing to commit."
+          fi


### PR DESCRIPTION
## Summary
- New workflow, `deploy-readme.yml`, pushes `src/readme.txt` to WordPress.org SVN trunk on its own, decoupled from a version release.
- Since `Stable tag: trunk`, WordPress.org reads plugin metadata straight from trunk's `readme.txt` - a readme-only change (`Tested up to`, `Tags`, description) doesn't need a version bump to go live. There was just never a path to ship one without a full release until now.
- Triggers on push to `master` touching `src/readme.txt`, plus `workflow_dispatch` for pushing the current state on demand (needed once, right after this merges, to pick up the `Tags`/License fix and `Tested up to: 7.0.4` bump already sitting on `master` unreleased).

## Test plan
- [ ] After merge, manually run via `gh workflow run deploy-readme.yml` and confirm the SVN trunk commit lands