### PR TITLE
ci: fix readme.txt SVN checkout depth, was empty not files

### DIFF
--- a/.github/workflows/deploy-readme.yml
+++ b/.github/workflows/deploy-readme.yml
@@ -30,13 +30,12 @@ jobs:
 
           SVN_DIR="${HOME}/svn-${SLUG}"
 
-          svn checkout --depth empty "${SVN_URL}/trunk" "${SVN_DIR}"
+          svn checkout --depth files "${SVN_URL}/trunk" "${SVN_DIR}"
           cp src/readme.txt "${SVN_DIR}/readme.txt"
 
           cd "${SVN_DIR}"
-          svn add --force readme.txt -q
 
-          if svn status | grep -q '^[MA]'; then
+          if svn status | grep -q '^M'; then
             svn commit -m "Update readme.txt" --no-auth-cache --non-interactive --username "${SVN_USERNAME}" --password "${SVN_PASSWORD}"
           else
             echo "readme.txt unchanged; nothing to commit."


### PR DESCRIPTION
## Summary
First live run of `deploy-readme.yml` (#224) failed: `svn checkout --depth empty` pulls the working-copy directory but no file metadata, so SVN had no revision record for `readme.txt` and treated the overwritten copy as a new file colliding with the one already on the server (`E155011`/`E160020`). `--depth files` actually checks out trunk's top-level files, including `readme.txt`, with real revision tracking.

## Test plan
- [ ] After merge, re-run via `gh workflow run deploy-readme.yml` and confirm the SVN commit actually lands this time