### PR TITLE
ci: authenticate release-please via GitHub App instead of PAT

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,10 +22,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v5
         id: release-please
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
Swaps `RELEASE_PLEASE_TOKEN` (a personal-account PAT) for a short-lived installation token minted from a dedicated GitHub App, so Release PRs stop being authored as a personal account and the credential isn't tied to any one person's account lifecycle.

- Adds an `actions/create-github-app-token` step ahead of `release-please-action`, reading `RELEASE_PLEASE_APP_ID` / `RELEASE_PLEASE_APP_PRIVATE_KEY`.
- Points `release-please-action`'s `token:` input at the minted token instead of `secrets.RELEASE_PLEASE_TOKEN`.

PR #222 (the old Release PR, authored under the PAT) has been closed and its branch deleted so merging this creates a fresh Release PR under the App's identity.