### PR TITLE
ci: request Jeff as reviewer on release-please PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -66,6 +66,22 @@ jobs:
           git commit -m "chore: draft changelog for ${version}"
           git push origin "$branch"
 
+      - name: Request review from Jeff
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_PLEASE_PR: ${{ steps.release-please.outputs.pr }}
+        run: |
+          set -euo pipefail
+
+          branch=$(echo "$RELEASE_PLEASE_PR" | jq -r '.headBranchName // empty')
+          if [ -z "$branch" ]; then
+            echo "No pending release-please PR found; skipping reviewer request."
+            exit 0
+          fi
+
+          pr_number=$(gh pr list --repo ${{ github.repository }} --head "$branch" --json number --jq '.[0].number')
+          gh pr edit "$pr_number" --repo ${{ github.repository }} --add-reviewer jfarthing84
+
   deploy:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'


### PR DESCRIPTION
Release PR is now authored by the App identity, not my personal account - it stopped showing up in my own PR list.

Adds a step requesting me as reviewer once a release-please PR exists, using the same branch-lookup as the existing changelog-drafting step.

Runs on every release-please push, not just PR creation. GitHub clears a submitted reviewer from the "requested reviewers" list once they've reviewed - this re-flags the PR after new commits land.