### PR TITLE
ci: add automated PR code review via claude-code-action

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,57 @@
+name: Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  review:
+    if: |
+      github.event.pull_request.draft == false &&
+      github.head_ref != 'release-please--branches--master'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request. The PR branch is already checked out
+            (as a detached HEAD) in the current working directory.
+
+            Focus on:
+            - Correctness bugs and edge cases introduced by this diff
+            - Security implications
+            - Adherence to any project CLAUDE.md guidelines
+
+            Post inline comments on specific lines where you find real issues.
+            Skip pedantic nitpicks and pre-existing issues not introduced by
+            this diff. If there's nothing worth flagging, say so briefly
+            instead of posting comments.
+
+            When you're done, submit a formal review summarizing what you
+            found. Always pass the PR number explicitly as
+            ${{ github.event.pull_request.number }} — do not omit it or rely
+            on branch inference, since the checkout is a detached HEAD:
+            - If you posted any inline comments (real issues), submit with
+              `gh pr review ${{ github.event.pull_request.number }} --comment --body "..."`.
+              Do NOT approve — issues were found.
+            - If you found nothing worth flagging, submit with
+              `gh pr review ${{ github.event.pull_request.number }} --approve --body "..."`
+              noting that the diff looks clean.
+            A plain comment review still shows up as "not approved" without
+            a hard block, which is what we want here.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review ${{ github.event.pull_request.number }} --approve:*),Bash(gh pr review ${{ github.event.pull_request.number }} --comment:*)"


### PR DESCRIPTION
Adds an always-on backstop review so a skipped manual review pass (like the one that let 3 bugs into the release-please cutover) can't slip through silently. Not a replacement for my own fresh-session review before merging - just a floor under it.

Uses `anthropics/claude-code-action` with `claude_code_oauth_token`, authenticated against the org's Claude subscription rather than metered API billing. Plain-prompt pattern, not the `code-review` plugin - the plugin's backgrounded pre-check never resumes in headless CI (matches several open upstream issues), so this follows Anthropic's own official example workflows instead.

Behavior:
- Runs on `opened`, `synchronize`, `ready_for_review`, `reopened`; skips drafts and release-please's own Release PR.
- Posts inline comments on real issues found.
- `--comment` (no approve) when issues are found, `--approve` only on a genuinely clean diff. Never `--request-changes` - blocked at the `allowedTools` permission level, not just prompt instruction.
- PR number always passed explicitly, since `actions/checkout` leaves the runner in a detached HEAD on `pull_request` events and branch-based inference isn't reliable there.

Validated end-to-end on a throwaway sandbox repo first - inline comments, approve-only-when-clean, draft/ready-for-review handling, and the release-please exclusion.

Not part of this PR: whether to make the bot's approval a real merge-gate via the ruleset. That's a separate decision.