### PR TITLE
ci: make changelog drafting idempotent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,8 @@ Allowed types:
 
 `feat`/`fix`/`perf` are the only types that ship in the plugin's changelog and trigger a version bump. The rest are invisible to plugin users by design.
 
+**A `readme.txt`-only change is always `chore`, even when it's user-facing** (e.g. correcting the `Tags`/`License` fields, bumping `Tested up to`). `readme.txt` is read straight off SVN trunk for the WordPress.org directory listing (`Stable tag: trunk`) and deploys independently via `deploy-readme.yml` on every push to `master` that touches it — it doesn't need a version bump to reach users, so it shouldn't trigger one. Reserve `fix`/`feat` for changes that need a new plugin build to reach users.
+
 **Branch names should be prefixed with the same type**, e.g. `fix/nonce-check-on-license-page`, `feat/passwordless-login`, `chore/bump-phpunit`.
 
 ### Squashing

--- a/bin/draft-changelog.php
+++ b/bin/draft-changelog.php
@@ -9,6 +9,11 @@
  * folding duplicates, "Tested up to" bullets) while reviewing the Release PR
  * it gets committed onto - not a finished changelog. See CONTRIBUTING.md.
  *
+ * Safe to re-run: replaces any existing block for the given version
+ * instead of appending a duplicate. Re-running discards hand edits made
+ * to that block since the last run - only hand-edit right before merging
+ * the Release PR, not mid-review.
+ *
  * Usage: php bin/draft-changelog.php <version>
  */
 
@@ -86,8 +91,22 @@ if ( false === $pos ) {
 	exit( 1 );
 }
 
-$insert_at = $pos + strlen( $marker );
-$readme    = substr( $readme, 0, $insert_at ) . "\n\n" . $entry . substr( $readme, $insert_at );
+$head          = substr( $readme, 0, $pos + strlen( $marker ) );
+$changelog_raw = ltrim( substr( $readme, $pos + strlen( $marker ) ), "\n" );
+
+// Split on version headings and drop any existing block for this version,
+// so re-running the script replaces it instead of appending a duplicate -
+// splitting on heading lines (rather than matching bullet lines) handles
+// hand-edited bullets that wrap onto a continuation line too.
+$blocks = preg_split( '/(?=^= .+ =$)/m', $changelog_raw );
+$blocks = array_filter(
+	$blocks,
+	static function ( $block ) use ( $version ) {
+		return 0 !== strpos( ltrim( $block ), "= {$version} =" );
+	}
+);
+
+$readme = $head . "\n\n" . $entry . "\n\n" . implode( '', $blocks );
 
 file_put_contents( $readme_path, $readme );
 


### PR DESCRIPTION
## Summary
- Re-running `bin/draft-changelog.php` for a pending version appended a duplicate `= X.Y.Z =` block instead of replacing it — this fires on every qualifying push while a Release PR is open, so it would have grown unbounded.
- Separately, `CONTRIBUTING.md` didn't document that readme.txt-only changes are `chore`, not `fix`/`feat`, regardless of whether they're user-facing on the WP.org directory listing — `deploy-readme.yml` already ships those independently of a version release. That gap is why the Tags/License readme correction got typed `fix` and pulled an unrelated version bump into its wake.

## Fix
- Strip any existing `= {version} =` block before inserting the freshly computed one, so the draft is safe to re-run.
- Document the readme.txt/chore exception in `CONTRIBUTING.md`.

## Test plan
- [x] Verified locally in a scratch clone: re-running for the same version replaces the block instead of duplicating it.