### PR TITLE
fix: default network admin menu items to manage_network_options

### DIFF
--- a/src/admin/class-theme-my-login-admin.php
+++ b/src/admin/class-theme-my-login-admin.php
@@ -68,7 +68,7 @@ final class Theme_My_Login_Admin {
 				'menu_title'  => '',
 				'menu_slug'   => '',
 				'parent_slug' => 'theme-my-login',
-				'capability'  => 'manage_options',
+				'capability'  => is_network_admin() ? 'manage_network_options' : 'manage_options',
 				'function'    => 'tml_admin_settings_page',
 			)
 		);

--- a/tests/test-admin-class.php
+++ b/tests/test-admin-class.php
@@ -91,6 +91,53 @@ class Test_Admin_Class extends WP_UnitTestCase {
 		$this->assertTrue( $admin->has_page( 'tml-test-submenu' ) );
 	}
 
+	public function test_add_menu_item_defaults_capability_to_manage_options_outside_network_admin() {
+		$admin = Theme_My_Login_Admin::get_instance();
+
+		$admin->add_menu_item( array(
+			'page_title'  => 'Test Capability Site',
+			'menu_title'  => 'Test Capability Site',
+			'menu_slug'   => 'tml-test-capability-site',
+			'parent_slug' => '',
+		) );
+
+		$this->assertSame( 'manage_options', $this->get_registered_menu_capability( 'tml-test-capability-site' ) );
+	}
+
+	public function test_add_menu_item_defaults_capability_to_manage_network_options_in_network_admin() {
+		// A hook name ending in "-network" resolves is_network_admin() to
+		// true via $current_screen->in_admin('network') — see WP_Screen::get().
+		// The base test case resets $GLOBALS['current_screen'] to null before
+		// the next test runs, so no manual reset is needed here.
+		set_current_screen( 'toplevel_page_tml-test-network' );
+
+		$admin = Theme_My_Login_Admin::get_instance();
+
+		$admin->add_menu_item( array(
+			'page_title'  => 'Test Capability Network',
+			'menu_title'  => 'Test Capability Network',
+			'menu_slug'   => 'tml-test-capability-network',
+			'parent_slug' => '',
+		) );
+
+		$this->assertSame( 'manage_network_options', $this->get_registered_menu_capability( 'tml-test-capability-network' ) );
+	}
+
+	/**
+	 * add_menu_page() (WP core) stores the capability as index 1 of its
+	 * entry in the $menu global, keyed by position rather than slug — this
+	 * scans for the entry by slug (index 2) instead.
+	 */
+	protected function get_registered_menu_capability( $menu_slug ) {
+		foreach ( $GLOBALS['menu'] as $item ) {
+			if ( $item[2] === $menu_slug ) {
+				return $item[1];
+			}
+		}
+
+		return null;
+	}
+
 	public function test_has_page_is_false_for_an_unregistered_page() {
 		$admin = Theme_My_Login_Admin::get_instance();
 


### PR DESCRIPTION
## Summary
- `add_menu_item()` always defaulted `capability` to `manage_options`, even when registering a page on `network_admin_menu` (multisite). Now defaults to `manage_network_options` in network-admin context, `manage_options` otherwise.
- No call sites currently override `capability`, so this changes the default everywhere it's used, not just one page.

Currently not exploitable: WordPress core already restricts `wp-admin/network/` routing to super admins before this capability check runs. This closes the gap in case that assumption changes, or a future page relies on the default without overriding it.

## Test plan
- [x] `tests/test-admin-class.php` — new coverage asserting `add_menu_item()` resolves to `manage_options` outside network-admin context and `manage_network_options` inside it (via `set_current_screen()`).
- [x] Single-site install: confirm the main "Theme My Login" admin menu and settings pages still load and save for an admin user.
- [x] Multisite install: confirm the network admin settings page still loads for a super admin.

(Dropped the "non-super-admin blocked from the network URL" check from the original test plan — that's WordPress core's own `wp-admin/network/*.php` routing/capability gate, not this repo's code, so it's not something worth scripting or manually re-verifying here.)