### PR TITLE
feat: refresh default login form styling

### DIFF
--- a/src/assets/styles/alerts.css
+++ b/src/assets/styles/alerts.css
@@ -10,19 +10,31 @@
 	.tml-message,
 	.tml-success,
 	.tml-action-confirmaction .success {
-		border-left: 4px solid #00a0d2;
-		box-shadow: 1px 1px 2px 1px rgba(0, 0, 0, 0.1);
+		background: #fff;
+		border: 1px solid rgba(0, 0, 0, 0.1);
+		border-left-width: 4px;
+		border-left-color: #c3c4c7;
+		box-shadow: none;
 		display: block;
 		margin: 0 0 1em;
 		padding: 0.75em;
 	}
 
+	.tml-message {
+		border-color: rgba(56, 88, 233, 0.3);
+		border-left-color: #3858e9;
+	}
+
 	.tml-error {
-		border-left-color: #dc3232;
+		border-color: rgba(204, 24, 24, 0.3);
+		border-left-color: #cc1818;
+		background-color: #fcf0f0;
 	}
 
 	.tml-success,
 	.tml-action-confirmaction .success {
-		border-left-color: #46b450;
+		border-color: rgba(74, 184, 102, 0.3);
+		border-left-color: #4ab866;
+		background-color: #eff9f1;
 	}
 }

--- a/src/assets/styles/tml.css
+++ b/src/assets/styles/tml.css
@@ -7,6 +7,12 @@
 
 	.tml-field-wrap {
 		margin-bottom: 1em;
+
+		&:has(.tml-checkbox) {
+			align-items: center;
+			display: flex;
+			gap: 0.5em;
+		}
 	}
 
 	.tml-label {
@@ -15,6 +21,8 @@
 	}
 
 	.tml-checkbox {
+		vertical-align: middle;
+
 		+ .tml-label {
 			display: inline;
 		}
@@ -30,4 +38,38 @@
 		font-style: italic;
 		margin: 0.5em 0;
 	}
+}
+
+:where(.tml .tml-field) {
+	background-color: #fff;
+	border: 1px solid #8c8f94;
+	border-radius: 4px;
+	color: #2c3338;
+	padding: 0.75em 1em;
+}
+
+:where(.tml .tml-field:focus) {
+	border-color: #3c434a;
+	box-shadow: 0 0 0 1px #3c434a;
+	outline: 2px solid transparent;
+}
+
+:where(.tml .tml-button) {
+	background-color: #f6f7f7;
+	border: 1px solid #8c8f94;
+	border-radius: 4px;
+	color: #2c3338;
+	cursor: pointer;
+	padding: 0.75em 1.5em;
+}
+
+:where(.tml .tml-button:hover) {
+	background-color: #f0f0f1;
+	border-color: #6c7079;
+}
+
+:where(.tml .tml-button:focus) {
+	border-color: #3c434a;
+	box-shadow: 0 0 0 1px #3c434a;
+	outline: 2px solid transparent;
 }


### PR DESCRIPTION
## Summary
- Update `.tml-error`/`.tml-message`/`.tml-success` notice colors to match current WP core admin notice values (previous colors were from an older WP release), and add a subtle rgba border on all sides in addition to the existing left accent so notices read as defined boxes rather than floating text on light/white theme backgrounds.
- Add a neutral, structural-only default appearance for `.tml-field`/`.tml-button` (border, padding, radius, focus outline) — these previously had no styling of their own and looked bare on themes that don't globally style form elements. Wrapped in `:where()` so the whole rule carries zero specificity; any theme selector, even a bare `input`/`button` element selector, overrides it regardless of stylesheet load order.
- Center the `.tml-checkbox` + label pairing (e.g. "Remember Me") vertically via `:has(.tml-checkbox)` turning the wrap into a flex row, since `vertical-align` alone doesn't center against themes with oversized label text.

## Test plan
- [x] `npm run build` succeeds
- [x] `composer run lint`
- [x] `vendor/bin/phpunit` (341 tests)
- [x] Verified against screenshots on Twenty Twenty-Five and Twenty Fifteen; confirmed the zero-specificity fields/buttons defer to a theme's own button styling where present