### PR TITLE
Add a show/hide toggle to password fields

### DIFF
--- a/build.config.json
+++ b/build.config.json
@@ -3,7 +3,7 @@
     {
       "dir": "assets",
       "styles": {
-        "theme-my-login": ["tml.css", "alerts.css", "pass-strength.css"]
+        "theme-my-login": ["tml.css", "alerts.css", "pass-strength.css", "password-toggle.css"]
       },
       "scripts": "theme-my-login"
     },

--- a/src/assets/scripts/password-confirm.js
+++ b/src/assets/scripts/password-confirm.js
@@ -1,0 +1,15 @@
+( function ( $ ) {
+
+	var $pass2 = $( '#pass2' );
+
+	if ( ! $pass2.length ) {
+		return;
+	}
+
+	$pass2.closest( '.tml-field-wrap' ).hide();
+
+	$( '#pass1' ).on( 'input', function() {
+		$pass2.val( $( this ).val() );
+	} );
+
+} )( jQuery );

--- a/src/assets/scripts/password-toggle.js
+++ b/src/assets/scripts/password-toggle.js
@@ -1,0 +1,16 @@
+( function ( $ ) {
+
+	$( '.tml' ).on( 'click', '.tml-toggle-pwd', function() {
+		var button = $( this ),
+			input = button.siblings( 'input' ),
+			isHidden = 'password' === input.attr( 'type' );
+
+		input.attr( 'type', isHidden ? 'text' : 'password' );
+
+		button
+			.attr( 'aria-label', isHidden ? themeMyLogin.hidePasswordLabel : themeMyLogin.showPasswordLabel )
+			.find( '.dashicons' )
+				.toggleClass( 'dashicons-hidden', isHidden )
+				.toggleClass( 'dashicons-visibility', ! isHidden );
+	} );
+} )( jQuery );

--- a/src/assets/styles/password-toggle.css
+++ b/src/assets/styles/password-toggle.css
@@ -1,0 +1,27 @@
+.tml-pwd {
+	position: relative;
+
+	.tml-field {
+		padding-right: 2.5em;
+	}
+}
+
+.tml-toggle-pwd {
+	background: none;
+	border: 0;
+	cursor: pointer;
+	padding: 0.5em;
+	position: absolute;
+	right: 0;
+	top: 50%;
+	transform: translateY(-50%);
+
+	.dashicons {
+		color: #787c82;
+	}
+
+	&:focus {
+		box-shadow: 0 0 0 1px #3c434a;
+		outline: 2px solid transparent;
+	}
+}

--- a/src/includes/class-theme-my-login-form-field.php
+++ b/src/includes/class-theme-my-login-form-field.php
@@ -650,6 +650,18 @@ class Theme_My_Login_Form_Field {
 				$output .= $label;
 				break;
 
+			case 'password':
+				$output .= $label;
+				$output .= $error;
+				$output .= $args['control_before'];
+				$output .= '<div class="tml-pwd">';
+				$output .= '<input name="' . $this->get_name() . '" type="password" value="' . esc_attr( $this->get_value() ) . '"' . $attributes . ">\n";
+				// phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reuses WP core's translated wp-login.php string verbatim.
+				$output .= '<button type="button" class="tml-toggle-pwd" aria-label="' . esc_attr__( 'Show password' ) . '"><span class="dashicons dashicons-visibility" aria-hidden="true"></span></button>';
+				$output .= "</div>\n";
+				$output .= $args['control_after'];
+				break;
+
 			case 'radio-group':
 				$output .= $label;
 				$output .= $error;

--- a/src/includes/functions.php
+++ b/src/includes/functions.php
@@ -244,7 +244,7 @@ function tml_body_class( $classes ) {
 function tml_enqueue_styles() {
 	$suffix = SCRIPT_DEBUG ? '' : '.min';
 
-	wp_enqueue_style( 'theme-my-login', THEME_MY_LOGIN_URL . "assets/styles/theme-my-login$suffix.css", array(), THEME_MY_LOGIN_VERSION );
+	wp_enqueue_style( 'theme-my-login', THEME_MY_LOGIN_URL . "assets/styles/theme-my-login$suffix.css", array( 'dashicons' ), THEME_MY_LOGIN_VERSION );
 }
 
 /**
@@ -282,8 +282,12 @@ function tml_enqueue_scripts() {
 	$data = apply_filters(
 		'tml_script_data',
 		array(
-			'action' => tml_is_action() ? tml_get_action()->get_name() : '',
-			'errors' => tml_get_errors()->get_error_codes(),
+			'action'            => tml_is_action() ? tml_get_action()->get_name() : '',
+			'errors'            => tml_get_errors()->get_error_codes(),
+			// phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reuses WP core's translated wp-login.php strings verbatim.
+			'showPasswordLabel' => __( 'Show password' ),
+			// phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reuses WP core's translated wp-login.php strings verbatim.
+			'hidePasswordLabel' => __( 'Hide password' ),
 		)
 	);
 

--- a/tests/test-form-field.php
+++ b/tests/test-form-field.php
@@ -69,6 +69,17 @@ class Test_Form_Field extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'checked="checked"', $unchecked );
 	}
 
+	public function test_password_field_renders_a_visibility_toggle() {
+		$output = $this->field( 'pwd', array(
+			'type' => 'password',
+			'id'   => 'user_pass',
+		) )->render();
+
+		$this->assertStringContainsString( '<div class="tml-pwd">', $output );
+		$this->assertStringContainsString( 'type="password"', $output );
+		$this->assertStringContainsString( '<button type="button" class="tml-toggle-pwd"', $output );
+	}
+
 	public function test_dropdown_marks_the_matching_option_selected() {
 		$output = $this->field( 'role', array(
 			'type'    => 'dropdown',


### PR DESCRIPTION
We're adding a show/hide toggle to every password field (login, registration, password reset), styled and labeled to match WordPress core's own password-reveal control. It's been requested repeatedly on the WP.org support forum.

On registration and password-reset forms, the confirm-password field is now hidden and kept in sync with the first field via JS, the same hide-and-populate pattern WordPress core uses on its own password forms. It still renders normally, and is still validated server-side, for visitors without JS.

## Test plan
- [x] `composer lint` / `composer test` pass
- [x] Verified rendered markup and the JS bundle on a local dev install (login and registration forms)