### PR TITLE
Add a filter to disable autofocus on login/register fields

### DIFF
--- a/src/assets/scripts/focus.js
+++ b/src/assets/scripts/focus.js
@@ -5,7 +5,7 @@
 	function initFocus() {
 		var userLogin, key;
 
-		if ( ! themeMyLogin.action ) {
+		if ( ! themeMyLogin.action || ! themeMyLogin.autofocus ) {
 			return;
 		}
 

--- a/src/includes/functions.php
+++ b/src/includes/functions.php
@@ -273,6 +273,15 @@ function tml_enqueue_scripts() {
 	wp_enqueue_script( 'theme-my-login', THEME_MY_LOGIN_URL . "assets/scripts/theme-my-login$suffix.js", $dependencies, THEME_MY_LOGIN_VERSION, true );
 
 	/**
+	 * Filter whether to autofocus the primary field on TML forms.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param bool $autofocus Whether to autofocus the primary field. Default true.
+	 */
+	$autofocus = (bool) apply_filters( 'tml_autofocus', true );
+
+	/**
 	 * Filter the main TML script data.
 	 *
 	 * @since 7.0.15
@@ -284,6 +293,7 @@ function tml_enqueue_scripts() {
 		array(
 			'action'            => tml_is_action() ? tml_get_action()->get_name() : '',
 			'errors'            => tml_get_errors()->get_error_codes(),
+			'autofocus'         => $autofocus,
 			// phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reuses WP core's translated wp-login.php strings verbatim.
 			'showPasswordLabel' => __( 'Show password' ),
 			// phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reuses WP core's translated wp-login.php strings verbatim.

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -654,6 +654,22 @@ class Test_Functions extends WP_UnitTestCase {
 		$this->assertTrue( $fired );
 	}
 
+	public function test_enqueue_scripts_localizes_autofocus_as_true_by_default() {
+		tml_enqueue_scripts();
+
+		$this->assertStringContainsString( '"autofocus":"1"', wp_scripts()->registered['theme-my-login']->extra['data'] );
+	}
+
+	public function test_enqueue_scripts_localizes_autofocus_as_false_when_filtered() {
+		add_filter( 'tml_autofocus', '__return_false' );
+
+		tml_enqueue_scripts();
+
+		remove_filter( 'tml_autofocus', '__return_false' );
+
+		$this->assertStringContainsString( '"autofocus":""', wp_scripts()->registered['theme-my-login']->extra['data'] );
+	}
+
 	// tml_do_login_head() / tml_do_login_footer()
 
 	public function test_do_login_head_is_a_no_op_outside_a_tml_action() {


### PR DESCRIPTION
## Summary
- TML currently autofocuses a field (username, password, activation key) on every action with no way to opt out.
- Adds a `tml_autofocus` filter (default `true`) that JS checks before focusing anything.

## Test plan
- [x] `composer test` (344 tests, includes two new cases covering the default and filtered-false paths)
- [x] `composer lint`