### PR TITLE
Fix extension updates failing to download from the Update Plugins screen

### DIFF
--- a/src/includes/extensions.php
+++ b/src/includes/extensions.php
@@ -114,6 +114,7 @@ function tml_add_extension_data_to_plugins_api( $result = false, $action = '', $
 			'license' => $extension->get_license_key(),
 			'item_id' => $extension->get_item_id(),
 			'slug'    => $extension->get_name(),
+			'url'     => home_url(),
 		)
 	);
 	if ( $result ) {
@@ -145,6 +146,7 @@ function tml_add_extension_data_to_plugins_transient( $transient = '' ) {
 				'license' => $extension->get_license_key(),
 				'item_id' => $extension->get_item_id(),
 				'slug'    => $extension->get_name(),
+				'url'     => home_url(),
 			)
 		);
 

--- a/tests/test-extensions.php
+++ b/tests/test-extensions.php
@@ -71,6 +71,23 @@ class Test_Extensions extends WP_UnitTestCase {
 		}, 10, 3 );
 	}
 
+	protected function capture_http_request_args( $body ) {
+		$captured = new stdClass();
+
+		add_filter( 'pre_http_request', function ( $preempt, $parsed_args, $url ) use ( $body, &$captured ) {
+			$this->http_request_count++;
+			$captured->args = $parsed_args['body'];
+
+			return array(
+				'response' => array( 'code' => 200, 'message' => 'OK' ),
+				'body'     => is_string( $body ) ? $body : wp_json_encode( $body ),
+				'headers'  => array(),
+			);
+		}, 10, 3 );
+
+		return $captured;
+	}
+
 	public function test_register_extension_adds_it_to_the_registry() {
 		$extension = $this->make_extension();
 
@@ -238,6 +255,16 @@ class Test_Extensions extends WP_UnitTestCase {
 		$this->assertSame( '2.0', $result->version );
 	}
 
+	public function test_add_extension_data_to_plugins_api_sends_the_site_url() {
+		tml_register_extension( $this->make_extension() );
+
+		$captured = $this->capture_http_request_args( array( 'new_version' => '2.0' ) );
+
+		tml_add_extension_data_to_plugins_api( 'original', 'plugin_information', (object) array( 'slug' => 'tml-test-extension' ) );
+
+		$this->assertSame( home_url(), $captured->args['url'] );
+	}
+
 	public function test_add_extension_data_to_plugins_transient_flags_an_available_update() {
 		$extension = tml_register_extension( $this->make_extension() );
 
@@ -258,5 +285,15 @@ class Test_Extensions extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( $extension->get_basename(), $transient->no_update );
 		$this->assertArrayNotHasKey( $extension->get_basename(), (array) ( $transient->response ?? array() ) );
+	}
+
+	public function test_add_extension_data_to_plugins_transient_sends_the_site_url() {
+		tml_register_extension( $this->make_extension() );
+
+		$captured = $this->capture_http_request_args( array( 'new_version' => '2.0', 'package' => 'https://example.org/download.zip' ) );
+
+		tml_add_extension_data_to_plugins_transient( (object) array() );
+
+		$this->assertSame( home_url(), $captured->args['url'] );
 	}
 }


### PR DESCRIPTION
## Summary
- The version-check request the plugins-transient and plugin-details hooks send to the store never included the site url, so the store's response always baked an empty url into the signed download link.
- WP core's actual download of that link then 401'd ("license not activated for this domain") regardless of the license's real activation state, for every customer, every extension, every time.
- Adds the missing `url` to both call sites, matching what license activation/deactivation already send correctly.

## Test plan
- [x] New tests in `tests/test-extensions.php` asserting the site url is sent on both the plugin-details and bulk-update-transient calls
- [x] `composer test` (346 tests) and `composer lint` pass