### PR TITLE
Credit reporter in 7.2.0 changelog entry

### DIFF
--- a/src/readme.txt
+++ b/src/readme.txt
@@ -64,7 +64,7 @@ Report bugs, suggest ideas and participate in development at [GitHub](https://gi
 = 7.2.0 =
 * Add a filter to disable autofocus on login/register fields
 * Add a show/hide toggle to password fields
-* Block multisite site creation when network registration is disabled
+* Block multisite site creation when network registration is disabled (props Jakub Herman)
 * Add default field/button styling
 * Update alert styling to match current WP core admin notices
 * Default network admin menu items to manage_network_options


### PR DESCRIPTION
## Summary

Adds "(props Jakub Herman)" to the 7.2.0 changelog bullet for the multisite registration-bypass fix, per the reporting researcher's request. `src/readme.txt` deploys independently of a release, so this doesn't need a version bump.

## Test plan

- [x] N/A - readme.txt only, no code changes