### PR TITLE
Stop unconfirmed privacy-request links from disclosing request status

### DIFF
--- a/src/includes/shortcodes.php
+++ b/src/includes/shortcodes.php
@@ -69,8 +69,8 @@ function tml_shortcode( $atts = array() ) {
 
 		$content = $form->render( $args );
 
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- request_id/confirm_key are validated via wp_validate_user_request_key() in tml_confirmaction_handler() before this branch is ever reached.
-	} elseif ( 'confirmaction' === $action->get_name() && isset( $_GET['request_id'] ) ) {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- request_id/confirm_key are validated via wp_validate_user_request_key() in tml_confirmaction_handler(), which tml_is_action() confirms has already run (template_redirect, before this shortcode renders) without wp_die()'ing on an invalid key.
+	} elseif ( 'confirmaction' === $action->get_name() && tml_is_action( 'confirmaction' ) && isset( $_GET['request_id'] ) ) {
 		$content = _wp_privacy_account_request_confirmed_message( $_GET['request_id'] );
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 

--- a/tests/test-shortcode.php
+++ b/tests/test-shortcode.php
@@ -37,6 +37,29 @@ class Test_Shortcode extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Ada Lovelace', $content );
 	}
 
+	public function test_confirmaction_renders_nothing_when_not_the_current_routed_action() {
+		$_GET['request_id'] = 1;
+
+		$content = tml_shortcode( array( 'action' => 'confirmaction' ) );
+
+		unset( $_GET['request_id'] );
+
+		$this->assertSame( '', $content );
+	}
+
+	public function test_confirmaction_renders_once_routed_as_the_current_action() {
+		global $wp;
+
+		$wp->query_vars['action'] = 'confirmaction';
+		$_GET['request_id']       = 1;
+
+		$content = tml_shortcode( array( 'action' => 'confirmaction' ) );
+
+		unset( $wp->query_vars['action'], $_GET['request_id'] );
+
+		$this->assertNotSame( '', $content );
+	}
+
 	public function test_shortcode_content_is_filterable() {
 		add_filter( 'tml_shortcode', function () {
 			return 'filtered content';


### PR DESCRIPTION
## Summary
- The `[theme-my-login]` shortcode's `confirmaction` branch rendered the account-request confirmation message directly from `$_GET['request_id']`, without checking that `confirm_key` had been validated — an anonymous visitor could probe any request ID and learn whether it exists.
- Gates that branch on `tml_is_action( 'confirmaction' )`, which is only true once the request has actually been routed through `tml_confirmaction_handler()` (on `template_redirect`, before shortcodes render) — an invalid key now `wp_die()`s there first.

## Test plan
- [x] Added `Test_Shortcode::test_confirmaction_renders_nothing_when_not_the_current_routed_action`
- [x] Added `Test_Shortcode::test_confirmaction_renders_once_routed_as_the_current_action`
- [x] `composer lint` and `composer test` (full suite, 348 tests) pass

Fixes #251