### PR TITLE
Fix activation/deactivation hooks registering against the wrong file on some install paths

### DIFF
--- a/src/includes/class-theme-my-login.php
+++ b/src/includes/class-theme-my-login.php
@@ -345,14 +345,11 @@ final class Theme_My_Login {
 		 */
 		do_action( 'tml_init', $this );
 
-		// Get the main plugin file path
-		$plugin_file = str_replace( array( 'src', 'build' ), '', THEME_MY_LOGIN_PATH . 'theme-my-login.php' );
-
 		// Run the activation hook
-		register_activation_hook( $plugin_file, array( $this, 'activate' ) );
+		register_activation_hook( THEME_MY_LOGIN_FILE, array( $this, 'activate' ) );
 
 		// Run the deactivation hook
-		register_deactivation_hook( $plugin_file, array( $this, 'deactivate' ) );
+		register_deactivation_hook( THEME_MY_LOGIN_FILE, array( $this, 'deactivate' ) );
 	}
 
 	/**

--- a/src/theme-my-login.php
+++ b/src/theme-my-login.php
@@ -38,6 +38,13 @@ define( 'THEME_MY_LOGIN_VERSION', '7.2.0' );
 define( 'THEME_MY_LOGIN_PATH', plugin_dir_path( __FILE__ ) );
 
 /**
+ * Stores the path to the plugin's main file, as registered with WordPress.
+ *
+ * @since 7.2.1
+ */
+define( 'THEME_MY_LOGIN_FILE', dirname( THEME_MY_LOGIN_PATH ) . '/theme-my-login.php' );
+
+/**
  * Stores the URL to TML.
  *
  * @since 7.0

--- a/tests/test-theme-my-login.php
+++ b/tests/test-theme-my-login.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Coverage for Theme_My_Login::__construct()'s activation/deactivation hook
+ * registration (src/includes/class-theme-my-login.php). It must register
+ * against THEME_MY_LOGIN_FILE, the plugin's actual main file as loaded by
+ * WordPress, not a path reconstructed by string manipulation that can be
+ * thrown off by install paths containing "src"/"build" outside the
+ * directory segment they're meant to identify.
+ *
+ * @package Theme_My_Login
+ */
+
+class Test_Theme_My_Login extends WP_UnitTestCase {
+
+	public function test_theme_my_login_file_points_to_the_real_plugin_file() {
+		$this->assertSame( dirname( THEME_MY_LOGIN_PATH ) . '/theme-my-login.php', THEME_MY_LOGIN_FILE );
+	}
+
+	public function test_activation_hook_is_registered_against_the_real_plugin_file() {
+		$basename = plugin_basename( THEME_MY_LOGIN_FILE );
+
+		$this->assertNotFalse(
+			has_action( 'activate_' . $basename, array( theme_my_login(), 'activate' ) )
+		);
+	}
+
+	public function test_deactivation_hook_is_registered_against_the_real_plugin_file() {
+		$basename = plugin_basename( THEME_MY_LOGIN_FILE );
+
+		$this->assertNotFalse(
+			has_action( 'deactivate_' . $basename, array( theme_my_login(), 'deactivate' ) )
+		);
+	}
+}


### PR DESCRIPTION
We derived the plugin's main file path by stripping the literal substrings `src`/`build` out of the loaded bootstrap file's path, which also matches those substrings anywhere else they occur in the install path (e.g. a `builds/` staging directory). That registers `register_activation_hook()`/`register_deactivation_hook()` against the wrong file, so they silently never fire - skipping the permalink flush and other setup/cleanup on activation and deactivation.

The root loader now records its own file path once at load time, and that's used directly instead of the reconstructed one. Added test coverage for the hook registration.

Fixes #252