### PR TITLE
Keep the password show/hide button from breaking under page button styles

### DIFF
--- a/src/assets/styles/password-toggle.css
+++ b/src/assets/styles/password-toggle.css
@@ -7,21 +7,27 @@
 }
 
 .tml-toggle-pwd {
-	background: none;
-	border: 0;
-	cursor: pointer;
-	padding: 0.5em;
-	position: absolute;
-	right: 0;
-	top: 50%;
-	transform: translateY(-50%);
+	background: none !important;
+	border: 0 !important;
+	box-shadow: none !important;
+	cursor: pointer !important;
+	display: block !important;
+	height: auto !important;
+	line-height: 1 !important;
+	margin: 0 !important;
+	padding: 0.5em !important;
+	position: absolute !important;
+	right: 0 !important;
+	top: 50% !important;
+	transform: translateY(-50%) !important;
+	width: auto !important;
 
 	.dashicons {
 		color: #787c82;
 	}
 
 	&:focus {
-		box-shadow: 0 0 0 1px #3c434a;
-		outline: 2px solid transparent;
+		box-shadow: 0 0 0 1px #3c434a !important;
+		outline: 2px solid transparent !important;
 	}
 }


### PR DESCRIPTION
I hardened `.tml-toggle-pwd` so it isn't at the mercy of whatever CSS a theme, plugin, or page-builder snippet applies to bare `<button>` elements. It now sets its background, border, sizing, and position with `!important`, so it stays a small icon button instead of getting reshaped or recolored by unrelated page styling.

Fixes #257

## Test plan

- [x] `npm run build` compiles the change into `theme-my-login.min.css` with no errors
- [x] Verified against real CSS pulled from the reporting user's site that the fix neutralizes the two conflicting rules found there