### PR TITLE
Enforce password validation on every registration entry point

### DIFF
--- a/src/includes/functions.php
+++ b/src/includes/functions.php
@@ -878,11 +878,11 @@ function tml_set_new_user_password( $user_id ) {
 		return;
 	}
 
-	// phpcs:disable WordPress.Security.NonceVerification.Missing -- mirrors WP core's own registration password handling (register_new_user()), which has no nonce of its own.
-	if ( empty( $_POST['user_pass1'] ) ) {
+	if ( tml_validate_new_user_password()->has_errors() ) {
 		return;
 	}
 
+	// phpcs:disable WordPress.Security.NonceVerification.Missing -- mirrors WP core's own registration password handling (register_new_user()), which has no nonce of its own.
 	wp_set_password( $_POST['user_pass1'], $user_id );
 	// phpcs:enable WordPress.Security.NonceVerification.Missing
 	update_user_option( $user_id, 'default_password_nag', false, true );

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -853,9 +853,36 @@ class Test_Functions extends WP_UnitTestCase {
 		$user_id = self::factory()->user->create();
 
 		$_POST['user_pass1'] = 'a-brand-new-password';
+		$_POST['user_pass2'] = 'a-brand-new-password';
 		tml_set_new_user_password( $user_id );
 
 		$this->assertTrue( wp_check_password( 'a-brand-new-password', get_userdata( $user_id )->user_pass, $user_id ) );
+	}
+
+	public function test_set_new_user_password_is_a_no_op_on_mismatched_passwords() {
+		update_site_option( 'tml_user_passwords', true );
+
+		$user_id = self::factory()->user->create();
+		$before  = get_userdata( $user_id )->user_pass;
+
+		$_POST['user_pass1'] = 'password-one';
+		$_POST['user_pass2'] = 'password-two';
+		tml_set_new_user_password( $user_id );
+
+		$this->assertSame( $before, get_userdata( $user_id )->user_pass );
+	}
+
+	public function test_set_new_user_password_is_a_no_op_on_a_backslash() {
+		update_site_option( 'tml_user_passwords', true );
+
+		$user_id = self::factory()->user->create();
+		$before  = get_userdata( $user_id )->user_pass;
+
+		$_POST['user_pass1'] = 'pass\\\\word';
+		$_POST['user_pass2'] = 'pass\\\\word';
+		tml_set_new_user_password( $user_id );
+
+		$this->assertSame( $before, get_userdata( $user_id )->user_pass );
 	}
 
 	// tml_handle_auto_login() bail branch (the enabled branch sets real auth cookies via setcookie(), out of scope here)


### PR DESCRIPTION
`tml_set_new_user_password()` set the submitted password straight from `$_POST` with no validation of its own, while `tml_validate_new_user_password()` (empty/backslash/mismatch checks) was only hooked to `registration_errors` on TML's own registration page. Posting directly to `wp-login.php?action=register` set the password without ever running those checks.

`tml_set_new_user_password()` now calls `tml_validate_new_user_password()` and bails if it returns errors, so the same checks apply regardless of which page the registration came through.

Fixes #253

## Test plan

- [x] `composer test` — full suite (353 tests) passes
- [x] `composer lint`
- [x] Added coverage for mismatched and backslash-containing passwords being rejected by `tml_set_new_user_password()`, and updated the existing "sets the submitted password" test to submit a matching confirmation field