### PR TITLE
Fix activation confirmation page breaking without an activation

### DIFF
--- a/src/includes/ms-functions.php
+++ b/src/includes/ms-functions.php
@@ -1289,7 +1289,7 @@ function tml_ms_filter_activation_shortcode( $content = '', $action = 'signup', 
 			}
 		} else {
 			$url  = isset( $result['blog_id'] ) ? get_home_url( (int) $result['blog_id'] ) : '';
-			$user = get_userdata( (int) $result['user_id'] );
+			$user = isset( $result['user_id'] ) ? get_userdata( (int) $result['user_id'] ) : false;
 
 			$content .= '<h2>' . __( 'Your account is now active!' ) . '</h2>';
 


### PR DESCRIPTION
## Summary
- Guards the `user_id` lookup in the multisite activation confirmation shortcode with the same `isset()` check already used for `blog_id`, so visiting the page without a routed activation shows a clean empty state instead of a PHP warning and garbled message.

Fixes #254

## Test plan
- [x] `composer lint`
- [x] `composer test` (353 tests, single site)
- [x] `vendor/bin/phpunit -c tests/phpunit/multisite.xml` (40 tests, multisite)