### PR TITLE
Block object injection in extension store API responses

### DIFF
--- a/src/includes/extensions.php
+++ b/src/includes/extensions.php
@@ -329,6 +329,26 @@ function tml_check_extension_license( $extension ) {
 }
 
 /**
+ * Unserialize a value if it is serialized, without allowing any objects.
+ *
+ * Behaves like `maybe_unserialize()`, except it restricts unserialization to
+ * plain arrays/scalars so a tampered store response can't instantiate an
+ * object and trigger a PHP object injection gadget chain.
+ *
+ * @since 7.2.1
+ *
+ * @param mixed $value The value to unserialize.
+ * @return mixed The unserialized value, or the original value if it wasn't serialized.
+ */
+function tml_maybe_unserialize_no_objects( $value ) {
+	if ( is_serialized( $value ) ) {
+		return unserialize( $value, array( 'allowed_classes' => false ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize -- allowed_classes is set to disable object injection.
+	}
+
+	return $value;
+}
+
+/**
  * Make an API call the store of an extension.
  *
  * @since 7.0
@@ -384,13 +404,13 @@ function tml_extension_api_call( $url, $args = array() ) {
 
 		if ( is_object( $response ) ) {
 			if ( isset( $response->sections ) ) {
-				$response->sections = maybe_unserialize( $response->sections );
+				$response->sections = tml_maybe_unserialize_no_objects( $response->sections );
 			}
 			if ( isset( $response->banners ) ) {
-				$response->banners = maybe_unserialize( $response->banners );
+				$response->banners = tml_maybe_unserialize_no_objects( $response->banners );
 			}
 			if ( isset( $response->icons ) ) {
-				$response->icons = maybe_unserialize( $response->icons );
+				$response->icons = tml_maybe_unserialize_no_objects( $response->icons );
 			}
 		} else {
 			$response = false;

--- a/tests/test-extensions.php
+++ b/tests/test-extensions.php
@@ -296,4 +296,34 @@ class Test_Extensions extends WP_UnitTestCase {
 
 		$this->assertSame( home_url(), $captured->args['url'] );
 	}
+
+	public function test_extension_api_call_unserializes_serialized_array_fields() {
+		tml_register_extension( $this->make_extension() );
+
+		$this->mock_http_response( array(
+			'new_version' => '2.0',
+			'icons'       => serialize( array( '1x' => 'https://example.org/icon.png' ) ),
+			'banners'     => serialize( array( 'low' => 'https://example.org/banner.png' ) ),
+		) );
+
+		$transient = tml_add_extension_data_to_plugins_transient( (object) array() );
+		$update    = $transient->response[ $this->make_extension()->get_basename() ];
+
+		$this->assertSame( array( '1x' => 'https://example.org/icon.png' ), $update->icons );
+		$this->assertSame( array( 'low' => 'https://example.org/banner.png' ), $update->banners );
+	}
+
+	public function test_extension_api_call_blocks_object_injection_in_serialized_fields() {
+		tml_register_extension( $this->make_extension() );
+
+		$this->mock_http_response( array(
+			'new_version' => '2.0',
+			'icons'       => serialize( new TML_Test_Extension( WP_PLUGIN_DIR . '/tml-test-extension/tml-test-extension.php' ) ),
+		) );
+
+		$transient = tml_add_extension_data_to_plugins_transient( (object) array() );
+		$update    = $transient->response[ $this->make_extension()->get_basename() ];
+
+		$this->assertNotInstanceOf( TML_Test_Extension::class, $update->icons );
+	}
 }


### PR DESCRIPTION
## Summary
- Fixes #264: extension store response fields (`sections`, `banners`, `icons`) were run through `maybe_unserialize()` with no restriction on which classes could be instantiated.
- Restricts unserialization to plain arrays/scalars, so a compromised or MITM'd store response can't trigger a PHP object injection gadget chain.

## Test plan
- [x] `composer lint`
- [x] `composer test` (full suite, 359 tests)
- [x] Added coverage for both the plain-unserialize path and the object-injection-blocked path