### PR TITLE
Cache extension update checks across requests

### DIFF
--- a/src/includes/extensions.php
+++ b/src/includes/extensions.php
@@ -349,6 +349,66 @@ function tml_maybe_unserialize_no_objects( $value ) {
 }
 
 /**
+ * Get the default arguments for an extension store API call.
+ *
+ * @since 7.2.1
+ *
+ * @return array The default arguments.
+ */
+function tml_get_extension_api_call_arg_defaults() {
+	return array(
+		'edd_action' => 'get_version',
+		'license'    => '',
+		'item_id'    => '',
+		'slug'       => '',
+		'url'        => '',
+		'beta'       => false,
+	);
+}
+
+/**
+ * Get the cache key tml_extension_api_call() uses for a given set of args.
+ *
+ * @since 7.2.1
+ *
+ * @param array $args The already-defaulted API call args.
+ * @return string The cache key.
+ */
+function tml_get_extension_api_call_cache_key( $args ) {
+	// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- one-way hash input for a cache key, never unserialized; no object-injection risk.
+	return md5( serialize( $args ) );
+}
+
+/**
+ * Clear the persistent extension version-check cache for every registered extension.
+ *
+ * Keeps the per-extension cache in sync with WordPress's own invalidation of
+ * its `update_plugins` transient (e.g. after installing or updating a
+ * plugin), the same way EDD_SL_Plugin_Updater does, instead of leaving it
+ * stuck serving a stale response for its full lifetime.
+ *
+ * @since 7.2.1
+ */
+function tml_clear_extension_version_check_cache() {
+	foreach ( tml_get_extensions() as $extension ) {
+		$args = wp_parse_args(
+			array(
+				'license' => $extension->get_license_key(),
+				'item_id' => $extension->get_item_id(),
+				'slug'    => $extension->get_name(),
+				'url'     => home_url(),
+			),
+			tml_get_extension_api_call_arg_defaults()
+		);
+
+		$cache_key = tml_get_extension_api_call_cache_key( $args );
+
+		wp_cache_delete( $cache_key, 'tml_api_calls' );
+		delete_site_transient( 'tml_api_call-' . $cache_key );
+	}
+}
+
+/**
  * Make an API call the store of an extension.
  *
  * @since 7.0
@@ -367,22 +427,21 @@ function tml_maybe_unserialize_no_objects( $value ) {
  * @return object|false The response object or false on failure.
  */
 function tml_extension_api_call( $url, $args = array() ) {
-	$args = wp_parse_args(
-		$args,
-		array(
-			'edd_action' => 'get_version',
-			'license'    => '',
-			'item_id'    => '',
-			'slug'       => '',
-			'url'        => '',
-			'beta'       => false,
-		)
-	);
+	$args = wp_parse_args( $args, tml_get_extension_api_call_arg_defaults() );
 
-	// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- one-way hash input for a cache key, never unserialized; no object-injection risk.
-	$cache_key = md5( serialize( $args ) );
+	// The passive version check is safe to cache across requests since it drives
+	// background/cron update checks; license activation/deactivation/status
+	// calls are one-off, user-initiated actions that must always reach the
+	// store live, so they're only deduped for the current request.
+	$cacheable = ( 'get_version' === $args['edd_action'] );
+
+	$cache_key = tml_get_extension_api_call_cache_key( $args );
 
 	$response = wp_cache_get( $cache_key, 'tml_api_calls' );
+	if ( ! $response && $cacheable ) {
+		$response = get_site_transient( 'tml_api_call-' . $cache_key );
+	}
+
 	if ( ! $response ) {
 		$response = wp_remote_post(
 			$url,
@@ -417,6 +476,9 @@ function tml_extension_api_call( $url, $args = array() ) {
 		}
 
 		wp_cache_set( $cache_key, $response, 'tml_api_calls' );
+		if ( $cacheable ) {
+			set_site_transient( 'tml_api_call-' . $cache_key, $response, DAY_IN_SECONDS / 2 );
+		}
 	}
 
 	return $response;

--- a/src/includes/hooks.php
+++ b/src/includes/hooks.php
@@ -100,3 +100,4 @@ add_filter( 'nav_menu_css_class', 'tml_nav_menu_css_class', 10, 2 );
 // Extensions
 add_filter( 'plugins_api', 'tml_add_extension_data_to_plugins_api', 10, 3 );
 add_filter( 'pre_set_site_transient_update_plugins', 'tml_add_extension_data_to_plugins_transient', 10, 1 );
+add_action( 'delete_site_transient_update_plugins', 'tml_clear_extension_version_check_cache', 10, 0 );

--- a/tests/test-extensions.php
+++ b/tests/test-extensions.php
@@ -3,7 +3,8 @@
  * Coverage for src/includes/extensions.php: the extension registry
  * (register/unregister/get/exists), the EDD-flavored license activation,
  * deactivation, and check calls, the shared tml_extension_api_call()
- * cache, and the WP plugins-API/update-transient integrations.
+ * request-scoped and persistent caching, and the WP
+ * plugins-API/update-transient integrations.
  *
  * Theme_My_Login_Extension is abstract, so tests use a minimal concrete
  * subclass with test-only license option names and store URL.
@@ -36,6 +37,9 @@ class Test_Extensions extends WP_UnitTestCase {
 		remove_all_filters( 'tml_extension_exists' );
 
 		wp_cache_flush_group( 'tml_api_calls' );
+
+		global $wpdb;
+		$wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->options WHERE option_name LIKE %s", $wpdb->esc_like( '_site_transient_tml_api_call-' ) . '%' ) );
 
 		parent::tearDown();
 	}
@@ -231,6 +235,56 @@ class Test_Extensions extends WP_UnitTestCase {
 		tml_check_extension_license( $extension );
 
 		$this->assertSame( 1, $this->http_request_count );
+	}
+
+	public function test_extension_api_call_persists_version_checks_in_a_site_transient() {
+		tml_register_extension( $this->make_extension() );
+
+		$this->mock_http_response( array( 'new_version' => '2.0' ) );
+
+		tml_add_extension_data_to_plugins_transient( (object) array() );
+
+		// Simulate a fresh request: the non-persistent object cache is gone,
+		// but the site transient survives.
+		wp_cache_flush_group( 'tml_api_calls' );
+
+		tml_add_extension_data_to_plugins_transient( (object) array() );
+
+		$this->assertSame( 1, $this->http_request_count );
+	}
+
+	public function test_extension_api_call_does_not_persist_license_checks_across_requests() {
+		$extension = tml_register_extension( $this->make_extension() );
+
+		$this->mock_http_response( array( 'license' => 'valid' ) );
+
+		tml_check_extension_license( $extension );
+
+		// Simulate a fresh request: license checks must always hit the store
+		// live, so this should not be served from a persistent cache.
+		wp_cache_flush_group( 'tml_api_calls' );
+
+		tml_check_extension_license( $extension );
+
+		$this->assertSame( 2, $this->http_request_count );
+	}
+
+	public function test_clear_extension_version_check_cache_forces_a_live_recheck() {
+		tml_register_extension( $this->make_extension() );
+
+		$this->mock_http_response( array( 'new_version' => '2.0' ) );
+
+		tml_add_extension_data_to_plugins_transient( (object) array() );
+
+		// Simulate WordPress invalidating its own update_plugins transient
+		// (e.g. after installing/updating a plugin).
+		delete_site_transient( 'update_plugins' );
+
+		wp_cache_flush_group( 'tml_api_calls' );
+
+		tml_add_extension_data_to_plugins_transient( (object) array() );
+
+		$this->assertSame( 2, $this->http_request_count );
 	}
 
 	public function test_add_extension_data_to_plugins_api_ignores_unrelated_actions() {


### PR DESCRIPTION
## Summary
- Persist extension version-check responses in a site transient (~12h) so plugin-update checks (dashboard load, wp-cron, `wp plugin update --all`) stop re-firing a blocking HTTP request per licensed extension on every run.
- License activate/deactivate/check calls stay live (request-scoped dedupe only), since those are one-off user actions where stale cached status would be wrong.

## Test plan
- [x] `composer test` (361 tests, including two new tests covering persistence across a simulated fresh request for version checks vs. license checks)
- [x] `composer lint`

Fixes #265