### PR TITLE
Sanitize action slugs for use in rewrite rules, not just text fields

### DIFF
--- a/src/admin/settings.php
+++ b/src/admin/settings.php
@@ -221,7 +221,7 @@ function tml_admin_get_settings_fields() {
 		$fields['tml_settings_slugs'][ $slug_option ] = array(
 			'title'             => $action->get_title(),
 			'callback'          => 'tml_admin_setting_callback_input_field',
-			'sanitize_callback' => 'sanitize_text_field',
+			'sanitize_callback' => 'sanitize_title',
 			'args'              => array(
 				'label_for'   => $slug_option,
 				'value'       => get_site_option( $slug_option, $action->get_slug() ),

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -125,6 +125,12 @@ class Test_Settings extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'tml_confirmaction_slug', $fields['tml_settings_slugs'], 'confirmaction has show_in_slug_settings = false and should be excluded.' );
 	}
 
+	public function test_slug_fields_are_sanitized_with_sanitize_title() {
+		$fields = tml_admin_get_settings_fields();
+
+		$this->assertSame( 'sanitize_title', $fields['tml_settings_slugs']['tml_login_slug']['sanitize_callback'], 'Slugs are interpolated directly into a rewrite rule regex in tml_add_rewrite_rules(), so sanitize_text_field() alone is not sufficient.' );
+	}
+
 	public function test_get_settings_fields_can_be_filtered() {
 		add_filter( 'tml_admin_get_settings_fields', function () {
 			return array( 'custom' => array() );


### PR DESCRIPTION
## Summary
- Action slug settings were sanitized with `sanitize_text_field()`, which strips tags/control characters but leaves regex metacharacters intact, and those slugs get compiled directly into a rewrite-rule regex in `tml_add_rewrite_rules()`.
- Switches the slug field's sanitize callback to `sanitize_title()`, matching how WordPress core sanitizes slug-like values elsewhere.

Fixes #268

## Test plan
- [x] `composer test` — 363 tests, all passing (added a regression test asserting the slug field's `sanitize_callback`)
- [x] `composer lint` — no new violations introduced (pre-existing unrelated findings confirmed present before this change)