### PR TITLE
Bump GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/deploy-readme.yml
+++ b/.github/workflows/deploy-readme.yml
@@ -16,7 +16,7 @@ jobs:
       SVN_URL: https://plugins.svn.wordpress.org/theme-my-login
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install svn
         run: sudo apt-get update -y && sudo apt-get install -y subversion

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,11 +22,11 @@ jobs:
       SVN_URL: https://plugins.svn.wordpress.org/theme-my-login
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.sha }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,13 +18,13 @@ jobs:
       sha: ${{ steps.release-please.outputs.sha }}
 
     steps:
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
`checkout` v4->v7, `create-github-app-token` v2->v3, `setup-node` v4->v7. Node 20 is removed from Actions runners this month; `release-please-action@v5` was already on Node 24.