### PR TITLE
Normalize trailing periods in drafted changelog bullets

### DIFF
--- a/bin/draft-changelog.php
+++ b/bin/draft-changelog.php
@@ -66,6 +66,12 @@ foreach ( $records as $record ) {
 		$text = trim( $matches[3] );
 	}
 
+	// commitlint's subject-full-stop rule already guarantees a subject never
+	// ends in a period, but nothing lints a `Release-Note:` trailer, so the
+	// two paths can disagree. Normalize the end of the text the same way
+	// ucfirst() normalizes the start. The lookbehind leaves an ellipsis alone.
+	$text = preg_replace( '/(?<!\.)\.\z/', '', $text );
+
 	$bullets[] = '* ' . ucfirst( $text );
 }
 


### PR DESCRIPTION
The 7.2.1 changelog draft came out with one bullet ending in a period while the other eleven didn't.

The cause is an asymmetry between the two sources of bullet text. `@commitlint/config-conventional` sets `subject-full-stop` to `never`, so a commit subject can't end in a period - but nothing lints a `Release-Note:` trailer, since it lives in the commit body. `bin/draft-changelog.php` was already normalizing the start of the text with `ucfirst()` and leaving the end alone, so whichever style the trailer happened to use went straight into `readme.txt`.

The script now strips a single trailing period, so both paths format identically regardless of how the trailer is written. The lookbehind leaves an ellipsis intact.

Merging this regenerates the pending 7.2.1 release PR's changelog block through the fixed script, which is also how the existing stray period gets cleaned up - so this should land before that release PR merges. Verified against the real `v7.2.0..HEAD` range: the affected bullet loses its period and the other eleven are unchanged.

No test accompanies this - `bin/` has no existing coverage and isn't in the phpcs scope either, and testing the script means standing up a throwaway git repo with fabricated commits. Worth doing, but as its own change rather than folded in here.