### PR TITLE
Escape the user's name in the dashboard greeting

### DIFF
--- a/src/includes/shortcodes.php
+++ b/src/includes/shortcodes.php
@@ -80,7 +80,7 @@ function tml_shortcode( $atts = array() ) {
 		$content .= '<div class="tml-dashboard-avatar">' . get_avatar( get_current_user_id() ) . '</div>';
 
 		// translators: %s: Current user's display name.
-		$content .= '<p class="tml-dashboard-greeting">' . sprintf( __( 'Howdy, %s' ), wp_get_current_user()->display_name ) . '</p>'; // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- intentionally reusing WP core's translated "Howdy, %s" string (see wp-includes/admin-bar.php), not a TML-specific string.
+		$content .= '<p class="tml-dashboard-greeting">' . sprintf( __( 'Howdy, %s' ), esc_html( wp_get_current_user()->display_name ) ) . '</p>'; // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- intentionally reusing WP core's translated "Howdy, %s" string (see wp-includes/admin-bar.php), not a TML-specific string.
 
 		/**
 		 * Filter the dashboard links.

--- a/tests/test-shortcode.php
+++ b/tests/test-shortcode.php
@@ -37,6 +37,25 @@ class Test_Shortcode extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Ada Lovelace', $content );
 	}
 
+	public function test_dashboard_action_escapes_the_display_name() {
+		global $wpdb;
+
+		$user_id = self::factory()->user->create();
+
+		// Core strips tags from display_name on save, so write it straight to
+		// the table - the case this guards against is a name that arrived by
+		// some other route (an import, another plugin, a direct query).
+		$wpdb->update( $wpdb->users, array( 'display_name' => '<script>alert(1)</script>' ), array( 'ID' => $user_id ) );
+		clean_user_cache( $user_id );
+
+		wp_set_current_user( $user_id );
+
+		$content = tml_shortcode( array( 'action' => 'dashboard' ) );
+
+		$this->assertStringNotContainsString( '<script>', $content );
+		$this->assertStringContainsString( '&lt;script&gt;', $content );
+	}
+
 	public function test_confirmaction_renders_nothing_when_not_the_current_routed_action() {
 		$_GET['request_id'] = 1;
 


### PR DESCRIPTION
The dashboard shortcode's greeting was the one dynamic value in that output going out unescaped, in an otherwise consistently-escaped file.

This isn't reachable through the profile screen - core strips tags from a display name on save - but a name that arrived by some other route (an import, another plugin, a direct query) was rendered as markup. `esc_html()` on the value closes that.

The accompanying test writes the name straight to the users table rather than going through `wp_update_user()`, since core's save-time sanitizing would otherwise make the test vacuous. Confirmed it fails without the fix, with raw script markup in the rendered output.

Fixes #272